### PR TITLE
Add CAS login protocol extension

### DIFF
--- a/src/main/resources/extensions/cas-login-protocol.json
+++ b/src/main/resources/extensions/cas-login-protocol.json
@@ -1,0 +1,9 @@
+{
+    "name": "CAS Login Procotol",
+    "description": "Implements the CAS SSO protocol according to official specification by adding a new client type to the Keycloak admin console. Supports CAS V1/V2/V3 with JSON or XML responses and attribute mapping. Full server implementation, no external components required.",
+    "maintainers": [
+        "Doccrazy"
+    ],
+    "website": "https://github.com/Doccrazy/keycloak-protocol-cas",
+    "download": "https://github.com/Doccrazy/keycloak-protocol-cas/releases"
+}


### PR DESCRIPTION
Add CAS login protocol extension from https://github.com/Doccrazy/keycloak-protocol-cas to extensions page (see Doccrazy/keycloak-protocol-cas#7).