### PR TITLE
Extension descriptions for modules "client authorization" and "full export endpoint"

### DIFF
--- a/src/main/resources/extensions/client-authorization.json
+++ b/src/main/resources/extensions/client-authorization.json
@@ -1,6 +1,6 @@
 {
     "name": "Client Authorization",
-    "description": "The purpose of this module is to add authorization capabilities to keycloak for a given client, whether the client itself has the capability to handle authorization or not. When installed, it allows the use of the Authorization client tab and a specific resource name (Keycloak Client Resource) to define the policies and permissions to grant access to the client. The effect is binary: either the client is allowed access to the client, and will recieve a token, or is not and will recieve an 'forbidden' message. Either way, the user is authenticated in keycloak and will have SSO access to the other clients for which they are authorized.",
+    "description": "The purpose of this module is to add authorization capabilities to keycloak for a given client, whether the client itself has the capability to handle authorization or not. When installed, it allows the use of a client's Authorization tab and a specific resource name (Keycloak Client Resource) to define the policies and permissions to grant access to the client. The effect is binary: either the client is allowed access to the client and will recieve a token, or is not and will recieve a 'forbidden' message. Either way, the user is authenticated in keycloak and will have SSO access to the other clients for which they are authorized.",
     "maintainers": [
         "cloudtrust","AlistairDoswald","yelhouti"
     ],

--- a/src/main/resources/extensions/client-authorization.json
+++ b/src/main/resources/extensions/client-authorization.json
@@ -1,0 +1,9 @@
+{
+    "name": "Client Authorization",
+    "description": "The purpose of this module is to add authorization capabilities to keycloak for a given client, whether the client itself has the capability to handle authorization or not. When installed, it allows the use of the Authorization client tab and a specific resource name (Keycloak Client Resource) to define the policies and permissions to grant access to the client. The effect is binary: either the client is allowed access to the client, and will recieve a token, or is not and will recieve an 'forbidden' message. Either way, the user is authenticated in keycloak and will have SSO access to the other clients for which they are authorized.",
+    "maintainers": [
+        "cloudtrust","AlistairDoswald","yelhouti"
+    ],
+    "website": "https://github.com/cloudtrust/keycloak-authorization",
+    "download": "https://github.com/cloudtrust/keycloak-authorization/releases"
+}

--- a/src/main/resources/extensions/export-endpoint.json
+++ b/src/main/resources/extensions/export-endpoint.json
@@ -1,0 +1,9 @@
+{
+    "name": "Full export endpoint",
+    "description": "Provides an endpoint allowing the full export of a realm, without having to restart keycloak. Secrets are exported in clear.",
+    "maintainers": [
+        "cloudtrust","yelhouti"
+    ],
+    "website": "https://github.com/cloudtrust/keycloak-export",
+    "download": "https://github.com/cloudtrust/keycloak-export/releases"
+}

--- a/src/main/resources/extensions/wsfed-protocol.json
+++ b/src/main/resources/extensions/wsfed-protocol.json
@@ -1,0 +1,9 @@
+{
+    "name": "WS-Federation protocol",
+    "description": "Implementation of the WS-Federation passive requestor model according to the official specification (v1.2, see http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html). This extension adds a new keycloak admin theme, a new client type and a new identity provider type to the admin console. Supports SAML 1.1 and SAML 2.0 tokens.",
+    "maintainers": [
+        "cloudtrust","AlistairDoswald","brat000012001","dbarentine"
+    ],
+    "website": "https://github.com/cloudtrust/keycloak-wsfed",
+    "download": "https://github.com/cloudtrust/keycloak-wsfed/releases"
+}


### PR DESCRIPTION
As suggested in the keycloak user mailing list [here](http://lists.jboss.org/pipermail/keycloak-user/2018-August/015125.html), and the keycloak dev mailing list [here](http://lists.jboss.org/pipermail/keycloak-dev/2018-August/011114.html), I'm submitting the descriptions of two modules developed for the cloudtrust project ("client authorization" and "full export endpoint") for the keycloak extensions page.