### PR TITLE
Upgrade to Wildfly 14. Added wildflyVersionAdapter and wildflyVersion…

### DIFF
--- a/src/main/java/org/keycloak/webbuilder/Version.java
+++ b/src/main/java/org/keycloak/webbuilder/Version.java
@@ -11,6 +11,10 @@ public class Version implements  Comparable<Version> {
 
     private String downloadTemplate;
 
+    private String wildflyVersionAdapter;
+
+    private String wildflyVersionAdapterDeprecated;
+
     private boolean latest;
 
     public boolean isFinal() {
@@ -49,6 +53,22 @@ public class Version implements  Comparable<Version> {
 
     public void setDownloadTemplate(String downloadTemplate) {
         this.downloadTemplate = downloadTemplate;
+    }
+
+    public String getWildflyVersionAdapter() {
+        return wildflyVersionAdapter;
+    }
+
+    public void setWildflyVersionAdapter(String wildflyVersionAdapter) {
+        this.wildflyVersionAdapter = wildflyVersionAdapter;
+    }
+
+    public String getWildflyVersionAdapterDeprecated() {
+        return wildflyVersionAdapterDeprecated;
+    }
+
+    public void setWildflyVersionAdapterDeprecated(String wildflyVersionAdapterDeprecated) {
+        this.wildflyVersionAdapterDeprecated = wildflyVersionAdapterDeprecated;
     }
 
     public String getDocumentationVersion() {

--- a/src/main/resources/templates/downloads-11.ftl
+++ b/src/main/resources/templates/downloads-11.ftl
@@ -96,8 +96,8 @@
                         <table class="table-downloads-inner">
                             <tr>
                                 <td>
-                                   13<br />
-                                   11, 10, 9 <b>*DEPRECATED*</b>
+                                   ${version.wildflyVersionAdapter}<br />
+                                   ${version.wildflyVersionAdapterDeprecated} <b>*DEPRECATED*</b>
                                 </td>
                                 <td>
                                     <@download category="adapter" label="wildfly" file="adapters/keycloak-oidc/keycloak-wildfly-adapter-dist-${version.version}" tar=true />
@@ -208,8 +208,8 @@
                         <table class="table-downloads-inner">
                             <tr>
                                 <td>
-                                   13<br />
-                                   11, 10, 9 <b>*DEPRECATED*</b>
+                                   ${version.wildflyVersionAdapter}<br />
+                                   ${version.wildflyVersionAdapterDeprecated} <b>*DEPRECATED*</b>
                                 </td>
                                 <td>
                                     <@download category="adapter-saml" label="wildfly" file="adapters/saml/keycloak-saml-wildfly-adapter-dist-${version.version}" tar=true />

--- a/src/main/resources/version-template.json
+++ b/src/main/resources/version-template.json
@@ -1,5 +1,7 @@
 {
   "version": "VERSION",
   "documentationTemplate": 6,
-  "downloadTemplate": 11
+  "downloadTemplate": 11,
+  "wildflyVersionAdapter": "14",
+  "wildflyVersionAdapterDeprecated": "13, 11, 10, 9"
 }

--- a/src/main/resources/versions/4.4.0.json
+++ b/src/main/resources/versions/4.4.0.json
@@ -1,5 +1,7 @@
 {
   "version": "4.4.0.Final",
   "documentationTemplate": 6,
-  "downloadTemplate": 11
+  "downloadTemplate": 11,
+  "wildflyVersionAdapter": "13",
+  "wildflyVersionAdapterDeprecated": "11, 10, 9"
 }

--- a/src/main/resources/versions/4.5.0.json
+++ b/src/main/resources/versions/4.5.0.json
@@ -1,5 +1,7 @@
 {
   "version": "4.5.0.Final",
   "documentationTemplate": 6,
-  "downloadTemplate": 11
+  "downloadTemplate": 11,
+  "wildflyVersionAdapter": "13",
+  "wildflyVersionAdapterDeprecated": "11, 10, 9"
 }


### PR DESCRIPTION
…AdapterDeprecated to the version template

PR adds wildflyVersionAdapter and wildflyVersionAdapterDeprecated to the version template, so that we don't need to create new downloads-X.ftl page everytime when wildfly version will be updated (as that will be quite often).

For Keycloak 4.4, 4.5 the Wildfly adapter versions are 13 and deprecated: 11, 10, 9. For Keycloak 4.6, it will be 14 and deprecated 13, 11, 10, 9.

PR can be applied after corresponding Wildfly14 upgrades PRs are applied to Keycloak master and Keycloak documentatio