### PR TITLE
Add entry about privacyIDEA 2FA

### DIFF
--- a/extensions/privacyidea-two-factor-authentication.json
+++ b/extensions/privacyidea-two-factor-authentication.json
@@ -1,0 +1,10 @@
+{
+    "name": "privacyIDEA two factor authentication",
+    "description": "This extenion adds 2nd factors to keycloak, that are authenticated against your central privacyIDEA system. The central privacyIDEA system can manage a lot of different token types for your users that are maybe already enrolled and used for other applications. Possible 2nd factors are HOTP, TOTP smartphone apps and hardware tokens, Email, SMS, Yubikeys, Nitrokeys, Push Token...",
+    "maintainers": [
+        "privacyidea"
+    ],
+    "website": "https://privacyidea.org",
+    "source": "https://github.com/privacyidea/keycloak-provider",
+    "download": "https://github.com/privacyidea/keycloak-provider/releases"
+}

--- a/extensions/privacyidea-two-factor-authentication.json
+++ b/extensions/privacyidea-two-factor-authentication.json
@@ -1,10 +1,11 @@
 {
     "name": "privacyIDEA two factor authentication",
-    "description": "This extenion adds 2nd factors to keycloak, that are authenticated against your central privacyIDEA system. The central privacyIDEA system can manage a lot of different token types for your users that are maybe already enrolled and used for other applications. Possible 2nd factors are HOTP, TOTP smartphone apps and hardware tokens, Email, SMS, Yubikeys, Nitrokeys, Push Token...",
+    "description": "This extenion adds 2nd factors to keycloak, that are authenticated against your central privacyIDEA system. privacyIDEA is a two factor management system that can manage a lot of different token types for your users.  Possible 2nd factors are e.g. HOTP, TOTP smartphone apps and hardware tokens, Email, SMS, Yubikeys, Nitrokeys, Push Token... privacyIDEA is completely Open Source licensed under the AGPLv3.",
     "maintainers": [
         "privacyidea"
     ],
     "website": "https://privacyidea.org",
     "source": "https://github.com/privacyidea/keycloak-provider",
-    "download": "https://github.com/privacyidea/keycloak-provider/releases"
+    "download": "https://github.com/privacyidea/keycloak-provider/releases",
+    "documentation": "https://community.privacyidea.org/t/how-to-use-keycloak-with-privacyidea/1132"
 }


### PR DESCRIPTION
privacyIDEA is a central 2FA system running on premise.
It can manage a lot of different token types for an organization.
The privacyidea keycloak extension enables those organizations to also use the enrolled tokens with keycloak.