### PR TITLE
Add json-remote-claim extension

### DIFF
--- a/extensions/json-remote-claim.json
+++ b/extensions/json-remote-claim.json
@@ -1,0 +1,11 @@
+{
+  "name": "JSON Remote Claim Mapper",
+  "description": "This module adds a new mapper type to retrieve JSON data from a remote HTTP endpoint (e.g. from a REST API) and add it as a claim into tokens or user info.",
+  "maintainers": [
+      "groupe-sii", "niroussel"
+  ],
+  "website": "https://github.com/groupe-sii/keycloak-json-remote-claim",
+  "download": "https://github.com/groupe-sii/keycloak-json-remote-claim",
+  "documentation": "https://github.com/groupe-sii/keycloak-json-remote-claim/blob/master/README.md",
+  "source": "https://github.com/groupe-sii/keycloak-json-remote-claim"
+}


### PR DESCRIPTION
An extension to add a new mapper type to retrieve JSON data from a remote HTTP endpoint (e.g. from a REST API) and add it as a claim into tokens or user info.

Extension discussed there: https://issues.redhat.com/browse/KEYCLOAK-12286