### PR TITLE
Add keycloak-config-cli

### DIFF
--- a/extensions/keycloak-config-cli.json
+++ b/extensions/keycloak-config-cli.json
@@ -1,0 +1,11 @@
+{
+  "name": "keycloak-config-cli - Configuration as Code for Keycloak realms",
+  "description": "keycloak-config-cli is a Keycloak utility to ensure the desired configuration state for a realm based on a JSON file. The format of the JSON file based on the export realm format. Store and handle the configuration files inside git just like normal code. A Keycloak restart isn't required to apply the configuration.",
+  "maintainers": [
+    "adorsys", "jkroepke"
+  ],
+  "website": "https://github.com/adorsys/keycloak-config-cli/",
+  "download": "https://github.com/adorsys/keycloak-config-cli/releases",
+  "documentation": "https://github.com/adorsys/keycloak-config-cli/blob/master/DOCUMENTATION.md",
+  "source": "https://github.com/adorsys/keycloak-config-cli.git"
+}


### PR DESCRIPTION
Hi,

keycloak-config-cli is a Keycloak utility to ensure the desired configuration state for a realm based on a JSON file. The format of the JSON file based on the export realm format. Store and handle the configuration files inside git just like normal code. A Keycloak restart isn't required to apply the configuration.

Please add keycloak-config-cli to the list of community extensions page.