### PR TITLE
[KEYCLOAK-17432] Upgrade to Wildfly 23

### DIFF
--- a/version-template.json
+++ b/version-template.json
@@ -3,6 +3,6 @@
   "version": "VERSION",
   "documentationTemplate": 7,
   "downloadTemplate": 17,
-  "wildflyVersionAdapter": "22",
-  "wildflyVersionAdapterDeprecated": "21, 20, 19, 18, 17, 16, 15, 14, 13, 11, 10, 9"
+  "wildflyVersionAdapter": "23",
+  "wildflyVersionAdapterDeprecated": "22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 11, 10, 9"
 }

--- a/version-template.json
+++ b/version-template.json
@@ -3,6 +3,6 @@
   "version": "VERSION",
   "documentationTemplate": 7,
   "downloadTemplate": 17,
-  "wildflyVersionAdapter": "21",
-  "wildflyVersionAdapterDeprecated": "20, 19, 18, 17, 16, 15, 14, 13, 11, 10, 9"
+  "wildflyVersionAdapter": "22",
+  "wildflyVersionAdapterDeprecated": "21, 20, 19, 18, 17, 16, 15, 14, 13, 11, 10, 9"
 }


### PR DESCRIPTION
    [KEYCLOAK-17432] Upgrade to Wildfly 23
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

_Note:_ Needs to be merged together with the following changes:
* [Code change](https://github.com/keycloak/keycloak/pull/7857)
* [Documentation change](https://github.com/keycloak/keycloak-documentation/pull/1145)