### PR TITLE
docs: add DB_VENDOR env to start keycloak container

### DIFF
--- a/guides/includes/getting-started/start-keycloak-container.adoc
+++ b/guides/includes/getting-started/start-keycloak-container.adoc
@@ -4,7 +4,7 @@ From a terminal start Keycloak with the following command:
 
 [source,bash,subs="attributes+"]
 ----
-{containerCommand} run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:{version}
+{containerCommand} run -p 8080:8080 -e DB_VENDOR=h2 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:{version}
 ----
 
 This will start Keycloak exposed on the local port 8080. It will also create an initial admin user with username `admin`


### PR DESCRIPTION
Using `h2` for demoing purposes and a one line demo.

On latest at time of this commit the default was not `h2` and I got an error saying could not connect to a database and it was trying to using `mysql` by default.