### PR TITLE
Add community extension "Testcontainers Keycloak"

### DIFF
--- a/extensions/testcontainers-keycloak.json
+++ b/extensions/testcontainers-keycloak.json
@@ -1,0 +1,9 @@
+{
+    "name": "Testcontainers Keycloak",
+    "description": "A Testcontainers implementation for Keycloak IAM & SSO. This provides a Testcontainers instance you can use in your integration tests, without being dependent on other infrastructure (besides Docker) or shared Keycloak deployments, being randomly changed by your co-workers.",
+    "maintainers": [
+        "dasniko"
+    ],
+    "website": "https://github.com/dasniko/testcontainers-keycloak",
+    "download": "https://search.maven.org/artifact/com.github.dasniko/testcontainers-keycloak"
+}


### PR DESCRIPTION
This is not really a Keycloak "extension", but IMHO a useful project the community should know about, thus adding it to the extensions page would be awesome.

The project already exists for 2 years and has ongoing download figures. From my experience and feedback from users, it's widely used across the community. Also, it's more or less "ready" for Keycloak.X, once it is released!