### PR TITLE
Specify supported Fuse versions in downloads section

### DIFF
--- a/templates/downloads-18.ftl
+++ b/templates/downloads-18.ftl
@@ -133,7 +133,7 @@
                     <td>
                         <table class="kc-table-downloads-inner">
                             <tr>
-                                <td>6.2, 6.3</td>
+                                <td>6.3, 7.x</td>
                                 <td>
                                     <@download category="adapter" label="fuse" file="keycloak-oidc-fuse-adapter-${version.version}" tar=true />
                                 </td>


### PR DESCRIPTION
Closes #256

@stianst Could you please take a look at it?

We test only the most recent versions of Fuse 6 and Fuse 7. Current tested version of Fuse 6 is `6.3` and it's the last released minor version of it. Therefore, I think the version `6.2` could be removed, because we're not so sure if it's working with it. And for Fuse 7, current tested version is 7.10, but it's changing a lot, so it'd be better to define version `7.x`? Or just `7`? I'd like to avoid confusions with only specified version `7`, when it might be associated with Fuse `7.0`. On the other hand, with specifying `7.x`, it might be associated with the fact that it's working with each minor version of Fuse 7. @stianst WDYT?