### PR TITLE
Fix user/password var names - remove "start-dev"

### DIFF
--- a/guides/includes/getting-started/start-keycloak-container.adoc
+++ b/guides/includes/getting-started/start-keycloak-container.adoc
@@ -4,7 +4,7 @@ From a terminal start Keycloak with the following command:
 
 [source,bash,subs="attributes+"]
 ----
-{containerCommand} run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:{version} start-dev
+{containerCommand} run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:{version}
 ----
 
 This will start Keycloak exposed on the local port 8080. It will also create an initial admin user with username `admin`


### PR DESCRIPTION
Edit for correct user and pwd var names and also removing "start-dev", it was causing jboss to abort the start procedure.