### PR TITLE
Revert "Update getting started guides to Quarkus dist"

### DIFF
--- a/guides/getting-started/getting-started-podman.adoc
+++ b/guides/getting-started/getting-started-podman.adoc
@@ -4,8 +4,8 @@
 :containerCommand: podman
 
 :links-local: true
-:links-admin-console: http://localhost:8080/admin[Keycloak Admin Console, window="_blank"]
-:links-account-console: http://localhost:8080/realms/myrealm/account[Keycloak Account Console, window="_blank"]
+:links-admin-console: http://localhost:8080/auth/admin[Keycloak Admin Console, window="_blank"]
+:links-account-console: http://localhost:8080/auth/realms/myrealm/account[Keycloak Account Console, window="_blank"]
 
 ## Before you start
 

--- a/guides/getting-started/getting-started-zip.adoc
+++ b/guides/getting-started/getting-started-zip.adoc
@@ -2,12 +2,12 @@
 :guide-summary: Get started with Keycloak on bare metal
 
 :links-local: true
-:links-admin-console: http://localhost:8080/admin[Keycloak Admin Console, window="_blank"]
-:links-account-console: http://localhost:8080/realms/myrealm/account[Keycloak Account Console, window="_blank"]
+:links-admin-console: http://localhost:8080/auth/admin[Keycloak Admin Console, window="_blank"]
+:links-account-console: http://localhost:8080/auth/realms/myrealm/account[Keycloak Account Console, window="_blank"]
 
 ## Before you start
 
-Make sure you have https://openjdk.java.net/[OpenJDK 11] or newer installed.
+Make sure you have https://openjdk.java.net/[OpenJDK 1.8] or newer installed.
 
 ## Download Keycloak
 

--- a/guides/includes/getting-started/create-admin-localhost.adoc
+++ b/guides/includes/getting-started/create-admin-localhost.adoc
@@ -3,4 +3,4 @@
 Keycloak does not come with a default admin user, which means before you can start using Keycloak you need to create
 an admin user.
 
-To do this open http://localhost:8080/[, window="_blank"], then fill in the form with your preferred username and password.
+To do this open http://localhost:8080/auth[, window="_blank"], then fill in the form with your preferred username and password.

--- a/guides/includes/getting-started/next.adoc
+++ b/guides/includes/getting-started/next.adoc
@@ -6,4 +6,4 @@ Before you go and run Keycloak in production there are a few more things that yo
 * Configure SSL with your own certificates
 * Switch the admin password to a more secure password
 
-For more information check out the https://www.keycloak.org/guides#server[server guides].
+For more information check out the https://www.keycloak.org/documentation[Keycloak Documentation].

--- a/guides/includes/getting-started/start-keycloak-container.adoc
+++ b/guides/includes/getting-started/start-keycloak-container.adoc
@@ -4,7 +4,7 @@ From a terminal start Keycloak with the following command:
 
 [source,bash,subs="attributes+"]
 ----
-{containerCommand} run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:{version} start-dev
+{containerCommand} run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin quay.io/keycloak/keycloak:{version}
 ----
 
 This will start Keycloak exposed on the local port 8080. It will also create an initial admin user with username `admin`

--- a/guides/includes/getting-started/start-keycloak-localhost.adoc
+++ b/guides/includes/getting-started/start-keycloak-localhost.adoc
@@ -6,12 +6,12 @@ On Linux run:
 
 [source,bash,subs="attributes+"]
 ----
-bin/kc.sh start-dev
+bin/standalone.sh
 ----
 
 On Windows run:
 
 [source,bash,subs="attributes+"]
 ----
-bin/kc.bat start-dev
+bin/standalone.bat
 ----

--- a/guides/securing-apps/vue.adoc
+++ b/guides/securing-apps/vue.adoc
@@ -4,7 +4,7 @@
 :author: akoserwal
 
 :links-local: true
-:links-admin-console: http://localhost:8080/admin[Keycloak Admin Console, window="_blank"]
+:links-admin-console: http://localhost:8080/auth/admin[Keycloak Admin Console, window="_blank"]
 
 ## Before you start
 
@@ -87,7 +87,7 @@ npm i vuejs-logger --save
 
 *InitOptions*: You can use a JSON file or an object with properties
 
-* Keycloak host URL: `https://127.0.0.1:8080/`
+* Keycloak host URL: `https://127.0.0.1:8080/auth`
 * Realm Name: `keycloak-demo`
 * Client ID: `app-vue`
 
@@ -98,7 +98,7 @@ Using the standard keycloak APIs init method call which returns a promise. On su
 [source,javascript,subs="attributes+"]
 ----
 let initOptions = {
-  url: 'http://127.0.0.1:8080/', realm: 'keycloak-demo', clientId: 'app-vue', onLoad: 'login-required'
+  url: 'http://127.0.0.1:8080/auth', realm: 'keycloak-demo', clientId: 'app-vue', onLoad: 'login-required'
 }
 
 let keycloak = Keycloak(initOptions);


### PR DESCRIPTION
The commands in the documentation are not working anymore 
e.g.
`docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:16.1.1 start-dev`

fails with following error

![image](https://user-images.githubusercontent.com/17722640/152902611-1b466e60-fac6-478c-a5f6-1b9e9cec7474.png)

This PR reverts commit 7a6f19d7bab04deb6d43ceda22036396f00191b2. 
as it should be merged after release 17.0.0

![image](https://user-images.githubusercontent.com/17722640/152902341-5080f967-7a5c-4d81-b094-f08bc5ba081c.png)

https://github.com/keycloak/keycloak/issues/9309

@stianst  this fixes #271 and #272
