### PR TITLE
Reference Keycloakify in guides

### DIFF
--- a/guides/theming/apisix.adoc
+++ b/guides/theming/apisix.adoc
@@ -1,0 +1,3 @@
+:guide-title: Keycloakify
+:guide-summary: Creation of Keycloak theme with React
+:external-link: https://www.keycloakify.dev

--- a/src/main/java/org/keycloak/webbuilder/Guides.java
+++ b/src/main/java/org/keycloak/webbuilder/Guides.java
@@ -218,7 +218,8 @@ public class Guides {
         GETTING_STARTED("getting-started", "Getting started"),
         SERVER("server", "Server"),
         OPERATOR("operator", "Operator"),
-        SECURING_APPS("securing-apps", "Securing applications");
+        SECURING_APPS("securing-apps", "Securing applications"),
+        THEMING("theming", "Theme creation");
 
         private String label;
 

--- a/src/main/java/org/keycloak/webbuilder/Links.java
+++ b/src/main/java/org/keycloak/webbuilder/Links.java
@@ -68,6 +68,8 @@ public class Links {
                 return "https://github.com/keycloak/keycloak/tree/main/docs/guides/src/main/operator/" + guide.getName() + ".adoc";
             case GETTING_STARTED:
                 return "https://github.com/keycloak/keycloak-web/tree/main/guides/getting-started/" + guide.getName() + ".adoc";
+            case THEMING:
+                return "https://github.com/keycloak/keycloak-web/tree/main/guides/theming/" + guide.getName() + ".adoc";
             default:
                 return null;
         }


### PR DESCRIPTION
Hello Keacloak team!  
First of all, congratulations for your great work, Key cloak has been improving fast lately!  

With this PR I offer to reference [Keycloakify](https://www.keycloakify.dev) in the guides as an external link.  
I have been spending some time creating a proper [documentation website](https://docs.keycloakify.dev).  

I hope you'll see it fitting.  

Best regard