### PR TITLE
docs: missing steps in docker getting-started guide

### DIFF
--- a/guides/includes/getting-started/first-app.adoc
+++ b/guides/includes/getting-started/first-app.adoc
@@ -8,6 +8,8 @@ Let's try to secure our first application. First step is to register this applic
 ** Client ID: `myclient`
 ** Client Protocol: `openid-connect`
 ** Root URL: `https://www.keycloak.org/app/`
+** Valid Redirect URIs: `https://www.keycloak.org/*`
+** Web origins: `https://www.keycloak.org`
 . Click `Save`
 
 image::{guideImages}/add-client.png[Add Client]
@@ -22,4 +24,4 @@ ifeval::[{links-local}!=true]
 Open https://www.keycloak.org/app/. Change `Keycloak URL` to the URL of your Keycloak instance. Click `Save`.
 endif::[]
 
-Now you can click `Sign in` to authenticate to this application using the Keycloak server you started earlier.
+Now you can click `Sign in` to authenticate to this application using the Keycloak server you started earlier. You should see `Hello, <your firstname> <your lastname>`.


### PR DESCRIPTION
Following the [Docker Getting Started Guide](https://www.keycloak.org/getting-started/getting-started-docker) does not fully work. This PR adds the missing steps.

- Need to set `Valid Redirect URIs` to not run into `Invalid parameter: redirect_uri` error.
- Need to set `Web origins` to not run into CORS error.
- Added expected result after sign-in.