### PR TITLE
docs: add apple identity provider to extension list

### DIFF
--- a/extensions/apple-identity-provider.json
+++ b/extensions/apple-identity-provider.json
@@ -1,0 +1,5 @@
+{
+    "name": "Apple Identity Provider",
+    "description": "<code>Sign in with Apple</code> using either a browser or natively by <code>token_exchange</code>.",
+    "website": "https://github.com/klausbetz/apple-identity-provider-keycloak"
+}


### PR DESCRIPTION
Added reference to an Apple Identity Provider extension.
See https://github.com/klausbetz/apple-identity-provider-keycloak/issues/9 @stianst 