### PR TITLE
Broken links on archived documentation

### DIFF
--- a/templates/documentation-11.ftl
+++ b/templates/documentation-11.ftl
@@ -100,31 +100,6 @@
     </tbody>
 </table>
 
-<h3 class="mt-4">Deprecated WildFly distribution</h3>
-
-<table class="table table-bordered table-striped">
-    <tr>
-        <td>
-            <a href="${docRoot}/server_installation/index.html" target="_blank">
-                Server Installation and Configuration
-            </a>
-        </td>
-        <td>
-            Installation and offline configuration of the Keycloak server
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <a href="https://github.com/keycloak/keycloak-containers/blob/${version.version}/server/README.md" target="_blank">
-                Server Container Image
-            </a>
-        </td>
-        <td>
-            Documentation specific to the server container image
-        </td>
-    </tr>
-</table>
-
 <h2 class="mt-4">API Documentation</h2>
 
 <table class="table table-bordered table-striped">

--- a/version-template.json
+++ b/version-template.json
@@ -2,6 +2,6 @@
   "date": "DATE",
   "version": "VERSION",
   "blogTemplate": 2,  
-  "documentationTemplate": 10,
+  "documentationTemplate": 11,
   "downloadTemplate": 21
 }

--- a/versions/19.0.0.json
+++ b/versions/19.0.0.json
@@ -2,6 +2,6 @@
   "date": "2022-07-27",
   "version": "19.0.0",
   "blogTemplate": 2,  
-  "documentationTemplate": 9,
+  "documentationTemplate": 10,
   "downloadTemplate": 20
 }

--- a/versions/19.0.1.json
+++ b/versions/19.0.1.json
@@ -2,6 +2,6 @@
   "date": "2022-07-29",
   "version": "19.0.1",
   "blogTemplate": 2,  
-  "documentationTemplate": 9,
+  "documentationTemplate": 10,
   "downloadTemplate": 20
 }

--- a/versions/19.0.2.json
+++ b/versions/19.0.2.json
@@ -2,6 +2,6 @@
   "date": "2022-09-14",
   "version": "19.0.2",
   "blogTemplate": 2,  
-  "documentationTemplate": 9,
+  "documentationTemplate": 10,
   "downloadTemplate": 20
 }

--- a/versions/19.0.3.json
+++ b/versions/19.0.3.json
@@ -2,6 +2,6 @@
   "date": "2022-10-06",
   "version": "19.0.3",
   "blogTemplate": 2,  
-  "documentationTemplate": 9,
+  "documentationTemplate": 10,
   "downloadTemplate": 20
 }

--- a/versions/20.0.0.json
+++ b/versions/20.0.0.json
@@ -2,6 +2,6 @@
   "date": "2022-11-01",
   "version": "20.0.0",
   "blogTemplate": 2,  
-  "documentationTemplate": 10,
+  "documentationTemplate": 11,
   "downloadTemplate": 21
 }

--- a/versions/20.0.1.json
+++ b/versions/20.0.1.json
@@ -2,6 +2,6 @@
   "date": "2022-11-01",
   "version": "20.0.1",
   "blogTemplate": 2,  
-  "documentationTemplate": 10,
+  "documentationTemplate": 11,
   "downloadTemplate": 21
 }


### PR DESCRIPTION
Closes #355

Turned out the new release process [publishes documentation](https://github.com/keycloak/keycloak.github.io/tree/main/docs) as three position version (e.g. `19.0.3`) instead of two (`19.0`). This makes sense from my perspective even though we link on the web just the minor versions (`19.0`) as it acts as a permalink to specific micro.