### PR TITLE
Fix title on archive download page

### DIFF
--- a/templates/downloads-archive-version.ftl
+++ b/templates/downloads-archive-version.ftl
@@ -1,15 +1,15 @@
 <#import "/templates/template.ftl" as tmpl>
 
-<@tmpl.page current="docs" title="Downloads ${version.versionShorter}" noindex=true>
+<@tmpl.page current="downloads" title="Downloads ${version.version}" noindex=true>
 
 <div class="container mt-5">
-    <h1>Documentation <span class="badge bg-primary">${version.versionShorter}</span></h1>
+    <h1>Downloads <span class="badge bg-primary">${version.version}</span></h1>
 
     <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="../downloads.html">Downloads</a></li>
         <li class="breadcrumb-item"><a href="../downloads-archive.html">Archive</a></li>
-        <li class="breadcrumb-item active">${version.versionShorter}</li>
+        <li class="breadcrumb-item active">${version.version}</li>
     </ol>
     </nav>
 


### PR DESCRIPTION
This is a screenshot of the reworked page from a local build:

* Title is fixed
* Version is fixed

![image](https://user-images.githubusercontent.com/3957921/220412213-56b38c18-bf71-45c2-a139-d42706020ea2.png)

Closes #376