### PR TITLE
Improve accessibility of the start page

### DIFF
--- a/pages/app/index.ftl
+++ b/pages/app/index.ftl
@@ -5,7 +5,7 @@
 <script src="keycloak.js" type="text/javascript"></script>
 <script src="app.js" type="text/javascript"></script>
 
-<div class="jumbotron jumbotron-fluid kc-bg-triangles py-5 kc-app">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles py-5 kc-app">
     <div class="container">
     <div class="row">
         <div class="card">

--- a/pages/blog.ftl
+++ b/pages/blog.ftl
@@ -2,7 +2,7 @@
 
 <@tmpl.page current="blog" title="Blog">
 
-<div class="jumbotron jumbotron-fluid kc-bg-triangles pt-4 pb-2">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-4 pb-2">
     <div class="container">
         <div class="row">
         <#assign displayed = 0>

--- a/pages/extensions.ftl
+++ b/pages/extensions.ftl
@@ -2,7 +2,7 @@
 
 <@tmpl.page current="extensions" title="Extensions">
 
-<div class="jumbotron jumbotron-fluid kc-bg-triangles pt-5">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-5">
     <div class="container">
         <h1 class="text-white">Extensions</h1>
 

--- a/pages/guides.ftl
+++ b/pages/guides.ftl
@@ -21,7 +21,7 @@
     </div>
 </nav>
 
-<div class="jumbotron jumbotron-fluid kc-bg-triangles pt-4">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-4">
     <div class="container">
         <#list guides.categories as c>
             <div class="row guide-category" id="${c.id}">

--- a/pages/index.ftl
+++ b/pages/index.ftl
@@ -2,8 +2,8 @@
 
 <@tmpl.page current="home" title="">
 
-<div class="jumbotron jumbotron-fluid kc-bg-triangles">
-  <div class="container text-white pt-4 pb-4">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles">
+  <div class="container pt-4 pb-4">
     <div class="row">
         <div class="col">
             <h1 class="fs-xlarge">Open Source Identity and Access Management</h1>
@@ -23,7 +23,7 @@
             </div>
         </div>
         <div class="col col-4 d-none d-lg-block">
-            <img class="img-fluid" src="${links.getResource('images/keycloak_icon_512px.svg')}" alt="Keycloak"/>
+            <img class="img-fluid" src="${links.getResource('images/keycloak_icon_512px.svg')}" aria-hidden="true" alt="Keycloak"/>
         </div>
     </div>
   </div>
@@ -57,7 +57,7 @@
             </p>
         </div>
         <div class="col-5 text-end d-none d-md-block">
-            <img class="img-fluid" src="resources/images/screen-login.png"/>
+            <img class="img-fluid" src="resources/images/screen-login.png" alt="Screenshot showing a user's login screen as presented by Keycloak"/>
         </div>
     </div>
 
@@ -74,7 +74,7 @@
             </p>
         </div>
         <div class="col-5 text-end d-none d-md-block">
-             <img class="img-fluid" src="resources/images/dia-identity-brokering.png"/>
+             <img class="img-fluid" src="resources/images/dia-identity-brokering.png" alt="Diagram illustrating brokering"/>
         </div>
     </div>
 
@@ -87,7 +87,7 @@
             </p>
         </div>
         <div class="col-5 text-end d-none d-md-block">
-             <img class="img-fluid" src="resources/images/dia-user-fed.png"/>
+             <img class="img-fluid" src="resources/images/dia-user-fed.png" alt="Diagram illustrating user federation"/>
         </div>
     </div>
 
@@ -109,7 +109,7 @@
             </p>
         </div>
         <div class="col-5 text-end d-none d-md-block">
-             <img class="img-fluid border" src="resources/images/screen-admin.png"/>
+             <img class="img-fluid border" src="resources/images/screen-admin.png" alt="Screenshot of the admin console"/>
         </div>
     </div>
 
@@ -129,7 +129,7 @@
             </p>
         </div>
         <div class="col-5 text-end d-none d-md-block">
-             <img class="img-fluid border" src="resources/images/screen-account.png"/>
+             <img class="img-fluid border" src="resources/images/screen-account.png" alt="Screenshot of the account management console"/>
         </div>
     </div>
 
@@ -141,7 +141,7 @@
             </p>
         </div>
         <div class="col-5 text-end d-none d-md-block">
-             <img class="img-fluid" src="resources/images/dia-protocols.png"/>
+             <img class="img-fluid" src="resources/images/dia-protocols.png" alt="Logos of OpenID certification, SAML and OAuth 2.0" aria-hidden="true"/>
         </div>
     </div>
 

--- a/resources/css/keycloak.css
+++ b/resources/css/keycloak.css
@@ -363,3 +363,8 @@ ol.toc-list .is-collapsed {
     color: #bf0000;
 }
 
+@media (prefers-contrast: more) {
+    .kc-bg-triangles {
+        background-image: none;
+    }
+}


### PR DESCRIPTION
This fixes some of the usability problems. 

The strategy for the background image: 
* Not show the background image if a person has chosen to see high contrast. Instead use the fallback color "bg-dark" on the start page, and "bg-light" on all other pages. 
* For standard users, increase the legibility by adding a shadow. 

The page now looks like this for regular users: 

![image](https://user-images.githubusercontent.com/3957921/220421923-9d41db79-9991-4563-8c44-a85a359acf9c.png)

When increased contrast has been chosen, it looks like this: 

![image](https://user-images.githubusercontent.com/3957921/220422559-77f7244e-df4a-432b-8e39-389abb0dc84c.png)

![image](https://user-images.githubusercontent.com/3957921/220422672-ed79e319-b5c9-4394-b606-05ad98568fc9.png)

It now reports for a local build significantly fewer errors. The remaining contrast problems with the links will be handled in a separate PR.

![image](https://user-images.githubusercontent.com/3957921/220422948-357cfa4a-31ae-4b1e-99f3-de84da7cd550.png)


See https://developer.chrome.com/docs/devtools/rendering/emulate-css/ on how to emulate those settings. 

Wave is available as a chrome plugin to run the tests locally: https://wave.webaim.org/extension/

Closes #354