### PR TITLE
Improve test application in smaller breakpoints

### DIFF
--- a/resources/css/keycloak.css
+++ b/resources/css/keycloak.css
@@ -252,8 +252,10 @@ ol.toc-list .is-collapsed {
 
 /* Test application */
 
-.kc-app {
-    padding: 400px;
+@media only screen and (min-width: 1400px) {
+    .kc-app {
+        padding: 400px;
+    }
 }
 
 .kc-app a.hide {


### PR DESCRIPTION
This adds a media query and only applies the padding on the `.kc-app` element for rather large screens.

**Before:**

![www keycloak org_app_(iPad Air)](https://user-images.githubusercontent.com/63866/230021528-f8e8513e-4f24-47f7-8235-e6439c67131e.png)

![www keycloak org_app_](https://user-images.githubusercontent.com/63866/230021707-bf018144-b74b-4604-8bf4-bb805a431184.png)

**After:**

![www keycloak org_app_(iPad Air) (1)](https://user-images.githubusercontent.com/63866/230021902-7ad9a366-a8d8-493a-a755-244f5dc5005e.png)

![www keycloak org_app_ (1)](https://user-images.githubusercontent.com/63866/230021803-5f858411-4346-4910-980b-f61f17c912a3.png)


