### PR TITLE
Fix instructions post cloning quickstarts repo

### DIFF
--- a/guides/securing-apps/vue.adoc
+++ b/guides/securing-apps/vue.adoc
@@ -31,7 +31,7 @@ NOTE: https://vuejs.org/v2/guide/installation.html#CSP-environments[CSP-environm
 [source,bash,subs="attributes+"]
 ----
 git clone https://github.com/keycloak/keycloak-quickstarts.git
-cd applications/app-vue/
+cd keycloak-quickstarts/applications/app-vue/
 npm install
 ----
 


### PR DESCRIPTION
The Vue.js instructions are incomplete: after cloning, you have to hop into the cloned repo before you can navigate around in it.
This PR fixes that.