### PR TITLE
Updates layout of tables in the Keycloak guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Can be built locally from IDE by running AutoBuilder main method or with Maven b
     
 After the build is completed open `target/web/index.html` in your favourite web browser.
     
-There's also an auto-builder utility that watches the filesystem and continiously rebuilds the website. This can be very useful when working on the website, especially making stylesheet changes, etc. This can be run from your IDE by running `AutoBuilder`, or from the command-line with:
+There's also an auto-builder utility that watches the filesystem and continuously rebuilds the website. This can be very useful when working on the website, especially making stylesheet changes, etc. This can be run from your IDE by running `AutoBuilder`, or from the command-line with:
 
     mvn -Pauto-run exec:java
 

--- a/resources/css/keycloak.css
+++ b/resources/css/keycloak.css
@@ -120,13 +120,20 @@ a:hover {
 }
 
 .kc-asciidoc th {
-    padding: 1.0rem 0.5rem 1rem 0;
+    padding: 0.5rem;
+    border: 1px solid #dee2e6;
+    background-color: #efefef;
 }
 
 .kc-asciidoc td {
     vertical-align: top;
     padding: 0.5rem;
     border: 1px solid #dee2e6;
+}
+
+/* the last paragraph in a table cell should not add additional margin, as the td already has a padding */
+.kc-asciidoc td p:last-of-type {
+    margin-bottom: 0;
 }
 
 .kc-asciidoc div.title {
@@ -159,6 +166,8 @@ table.options tr {
 
 table.options th {
     padding: 1.0rem 0.5rem;
+    border: none;
+    background-color: transparent;
 }
 
 table.options td {


### PR DESCRIPTION
This fixes the layout of the tables, as experienced for example on https://www.keycloak.org/server/db

Old layout, missing a proper table heading and too much distance at the bottom of the table cells: 

![image](https://github.com/keycloak/keycloak-web/assets/3957921/7964e39f-dbaf-4320-b8ad-1d8d64e3984c)

New layout after CSS changes:

![image](https://github.com/keycloak/keycloak-web/assets/3957921/9796e5b6-9695-4a41-bd71-fc5dd9ca968f)
