### PR TITLE
Add Traefik Hub to the guides

### DIFF
--- a/guides/securing-apps/traefik-hub.adoc
+++ b/guides/securing-apps/traefik-hub.adoc
@@ -1,0 +1,3 @@
+:guide-title: Traefik Hub
+:guide-summary: Use Keycloak as an identity provider or as an identity broker for Traefik Hub API management
+:external-link: https://doc.traefik.io/traefik-hub/user-mgmt/keycloak/


### PR DESCRIPTION
Similar to other external apps, add [Traefik Hub](https://traefik.io/traefik-hub/) API management to the "Securing applications" section of the guides: https://www.keycloak.org/guides#securing-apps