### PR TITLE
Add link to Discourse forum again

### DIFF
--- a/pages/community.ftl
+++ b/pages/community.ftl
@@ -10,6 +10,7 @@
             <li>Join <a href="https://cloud-native.slack.com/archives/C056HC17KK9">#keycloak</a>, or <a href="https://cloud-native.slack.com/archives/C056XU905S6">#keycloak-dev</a> on Slack for design discussions, or questions by creating an account at <a href="https://slack.cncf.io/">https://slack.cncf.io/</a></li>
             <li><a href="search.html">Search</a> for information in the documentation and mailing list</li>
             <li><a href="https://github.com/keycloak/keycloak/discussions">GitHub Discussions Forum</a> for discussions and asking questions</li>
+            <li><a href="https://keycloak.discourse.group/">Discourse Forum</a> where you can ask questions</li>
             <li><a href="https://groups.google.com/forum/#!forum/keycloak-user">Mailing list</a> where you can ask questions</li>
         </ul>
     </div>


### PR DESCRIPTION
Brings back the link to the revived Discourse forum, which was removed with https://github.com/keycloak/keycloak-web/pull/405
/cc @abstractj 