### PR TITLE
Redirect from pre-shared link to blog post

### DIFF
--- a/static/2023/11/kubecon-chicago.html
+++ b/static/2023/11/kubecon-chicago.html
@@ -1,0 +1,11 @@
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Redirecting to ../10/keycloak-kubeconf-chicago</title>
+<meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/2023/10/keycloak-kubeconf-chicago.html">
+<link rel="canonical" href="https://www.keycloak.org/2023/10/keycloak-kubeconf-chicago.html">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/2023/10/keycloak-kubeconf-chicago.html">https://www.keycloak.org/2023/10/keycloak-kubeconf-chicago.html</a>...
+</body>
+</html>


### PR DESCRIPTION
This redirects from a link share in the KubeCon keynote video `https://www.keycloak.org/2023/11/kubecon-chicago` to the already published blog post.
