### PR TITLE
update link to

### DIFF
--- a/guides/securing-apps/traefik-hub.adoc
+++ b/guides/securing-apps/traefik-hub.adoc
@@ -1,3 +1,3 @@
 :guide-title: Traefik Hub
 :guide-summary: Use Keycloak as an identity provider or as an identity broker for Traefik Hub API management
-:external-link: https://doc.traefik.io/traefik-hub/user-mgmt/keycloak/
+:external-link: https://doc.traefik.io/traefik-hub/authentication-authorization/idp/keycloak


### PR DESCRIPTION
This PR:

Update link to the new Keycloak location in the revamped Traefik Hub documentation.