### PR TITLE
The no-index functionality works only if the pages are allowed to be crawled

### DIFF
--- a/pages/blog-archive.ftl
+++ b/pages/blog-archive.ftl
@@ -1,6 +1,6 @@
 <#import "/templates/template.ftl" as tmpl>
 
-<@tmpl.page current="blog" title="Blog archive">
+<@tmpl.page current="blog" title="Blog archive" noindex=true>
 
 <div class="container mt-5 kc-article">
     <h1>Blog Archive</h1>

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,6 +1,1 @@
 User-agent: *
-Disallow: /archive/
-Disallow: /blog-archive.html
-Disallow: /blog-archive
-Disallow: /downloads-archive.html
-Disallow: /downloads-archive

--- a/templates/documentation-11.ftl
+++ b/templates/documentation-11.ftl
@@ -2,8 +2,10 @@
 
 <#if archive>
     <#assign docRoot = "${root}docs/${version.version}">
+    <#assign docApiRoot = "${root}docs-api/${version.version}">
 <#else>
     <#assign docRoot = "${root}docs/latest">
+    <#assign docApiRoot = "${root}docs-api/latest">
 </#if>
 
 <table class="table table-bordered table-striped">
@@ -106,7 +108,7 @@
     <tbody>
     <tr>
         <td>
-            <a href="${root}docs-api/${version.version}/javadocs/index.html" target="_blank">
+            <a href="${docApiRoot}/javadocs/index.html" target="_blank">
                 JavaDoc
             </a>
         </td>
@@ -116,7 +118,7 @@
     </tr>
     <tr>
         <td>
-            <a href="${root}docs-api/${version.version}/rest-api/index.html" target="_blank">
+            <a href="${docApiRoot}/rest-api/index.html" target="_blank">
                 Administration REST API
             </a>
         </td>


### PR DESCRIPTION
This change prevents hits in the Google search without content like the following: 

![image](https://github.com/keycloak/keycloak-web/assets/3957921/30166a3c-e447-4453-92fa-16527c043ddc)

See https://support.google.com/webmasters/answer/7489871?hl=en#zippy=%2Cthis-is-my-site%2Cthe-page-is-blocked-by-robotstxt for the explanation.

I'll create a follow-up issue to add canonical URLs to all old docs, so the content will eventually redirect to the latest versions.

Closes #460