### PR TITLE
Avoid Google complaining that the RSS feed contain a URL that is not a canonical link on the page

### DIFF
--- a/templates/rss.ftl
+++ b/templates/rss.ftl
@@ -6,7 +6,7 @@
 
 <channel>
   <title>Keycloak Blog</title>
-  <link>https://www.keycloak.org/blog.html</link>
+  <link>${ links.blog }</link>
   <atom:link href="${home}/rss.xml" rel="self" type="application/rss+xml" />
   <description>Keycloak Blog</description>
   <language>en-us</language>


### PR DESCRIPTION
This error appeared in the search console. All other feed URLs are already pointing to the canonical URLs.

![image](https://github.com/keycloak/keycloak-web/assets/3957921/8dbf7e79-0ff4-4188-97ca-16a892058cf5)
