### PR TITLE
Remove Tomcat adapter from OIDC and SAML downloads. Remove SAML downl…

### DIFF
--- a/templates/downloads-24.ftl
+++ b/templates/downloads-24.ftl
@@ -1,0 +1,132 @@
+<#macro download category label file tar=true zip=true>
+<#if zip>
+<span class="me-4">
+<a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.zip" target="_blank">
+    <i class="fa fa-download" aria-hidden="true"></i>
+    ZIP
+</a>
+(<a href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.zip.sha1" target="_blank">sha1</a>)
+</span>
+</#if>
+<#if tar>
+<span>
+<a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tar.gz" target="_blank">
+    <i class="fa fa-download" aria-hidden="true"></i>
+    TAR.GZ
+</a>
+(<a href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tar.gz.sha1" target="_blank">sha1</a>)
+</span>
+</#if>
+</#macro>
+
+<h2 class="mt-4">Server</h2>
+
+<table class="table table-bordered table-striped">
+    <tbody>
+    <tr>
+        <td>Keycloak</td>
+        <td>Distribution powered by Quarkus</td>
+        <td>
+            <@download category="server" label="standalone" file="keycloak-${version.version}" />
+        </td>
+    </tr>
+    <tr>
+        <td>Container image</td>
+        <td>For Docker, Podman, Kubernetes and OpenShift</td>
+        <td>
+            <a href="https://quay.io/repository/keycloak/keycloak" target="_blank">
+                <i class="fa fa-link"></i>
+                Quay
+            </a>
+        </td>
+    </tr>
+    <tr>
+        <td>Operator</td>
+        <td>For Kubernetes and OpenShift</td>
+        <td>
+            <a href="https://operatorhub.io/operator/keycloak-operator" target="_blank">
+                <i class="fa fa-link"></i>
+                OperatorHub
+            </a>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<h2 class="mt-4">Quickstarts</h2>
+<table class="table table-bordered table-striped">
+    <tbody>
+
+    <tr>
+        <td>Quickstarts distribution</td>
+        <td>
+            <span class="me-4">
+            <#if quickstartsTag??>
+                <#assign quickstartsLink="https://github.com/keycloak/keycloak-quickstarts/tree/${version.version}"/>
+            <#else>
+                <#assign quickstartsLink="https://github.com/keycloak/keycloak-quickstarts"/>
+            </#if>
+
+            <a onclick="dl('examples', 'quickstarts');" href="${quickstartsLink}" target="_blank">
+                <i class="fab fa-github" aria-hidden="true"></i>
+                GitHub
+            </a>
+            </span>
+            <span>
+            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/latest.zip" target="_blank">
+                <i class="fa fa-download" aria-hidden="true"></i>
+                ZIP
+            </a>
+            </span>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+<h2 class="mt-4">Client Adapters</h2>
+
+<div>
+
+    <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active margin-top" id="oidc">
+            <table class="table table-bordered table-striped">
+                <tr>
+                    <td>JavaScript</td>
+                    <td>
+                        <table class="kc-table-downloads-inner">
+                            <tr>
+                                <td></td>
+                                <td>
+                                    <span class="me-4">
+                                    <a href="https://www.npmjs.com/package/keycloak-js/v/${version.version}" target="_blank">
+                                        <i class="fa fa-link"></i> NPM
+                                    </a>
+                                    </span>
+                                    <@download category="adapter" label="js" file="keycloak-oidc-js-adapter-${version.version}" tar=true />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Node.js <b>[DEPRECATED]</b></td>
+                    <td>
+                        <table class="kc-table-downloads-inner">
+                            <tr>
+                                <td></td>
+                                <td>
+                                    <a href="https://www.npmjs.com/package/keycloak-connect/v/${version.version}" target="_blank">
+                                        <i class="fa fa-link"></i> NPM
+                                    </a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+</div>

--- a/version-template.json
+++ b/version-template.json
@@ -3,5 +3,5 @@
   "version": "VERSION",
   "blogTemplate": 3,
   "documentationTemplate": 11,
-  "downloadTemplate": 23
+  "downloadTemplate": 24
 }


### PR DESCRIPTION
…oads section entirely

closes keycloak/keycloak#28776


This PR removes Tomcat adapter from "downloads" for both OIDC and SAML. The PR also removes tabs `OpenID Connect` and `SAML` entirely from `Client adapters` section as we don't have any SAML adapters for the downloads.

Snapshot of how it looks like:

![Screenshot from 2024-05-06 08-50-07](https://github.com/keycloak/keycloak-web/assets/1223965/f3790086-c3e1-4804-a12f-ce1635cf9298)
