### PR TITLE
Adding GitHub stars to the Keycloak homepage

### DIFF
--- a/templates/template.ftl
+++ b/templates/template.ftl
@@ -28,9 +28,11 @@
 
 <header class="navbar navbar-expand-md bg-light shadow-sm">
 <nav class="container-xxl flex-wrap flex-md-no-wrap navbar-light">
-    <a class="navbar-brand me-5" href="${links.home}">
+    <a class="navbar-brand me-3 me-md-4 me-lg-5" href="${links.home}">
         <img class="img-fluid" src="${links.getResource('images/logo.svg')}" width="240" alt="Keycloak"/>
     </a>
+    <a class="nav-link d-none d-sm-block d-md-none d-lg-block" href="https://github.com/keycloak/keycloak"><img src="https://img.shields.io/github/stars/keycloak/keycloak?label=GitHub%20Stars" style="height: 25px" alt="GitHub stars"/></a>
+    <a class="nav-link d-block d-sm-none d-md-block d-lg-none" href="https://github.com/keycloak/keycloak"><img src="https://img.shields.io/github/stars/keycloak/keycloak?label=" style="height: 25px" alt="GitHub stars"/></a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="fa fa-bars fa-lg px-1 py-2"></span>
     </button>


### PR DESCRIPTION
Closes #465

At the time of writing this, Keycloak has 20277 GitHub stars.

This adds the widget at different breakpoints: 

![image](https://github.com/keycloak/keycloak-web/assets/3957921/e29b8b22-708d-4bd5-b886-6734338f421b)

![image](https://github.com/keycloak/keycloak-web/assets/3957921/8d8f82c5-126f-45da-a69f-7a68c55d7cf1)

![image](https://github.com/keycloak/keycloak-web/assets/3957921/10655fe6-01c4-4e12-aa8c-fa36f1887223)

![image](https://github.com/keycloak/keycloak-web/assets/3957921/76a77355-0abf-4eac-9d25-1519394d1118)

There is also the option to add this as an embedded SVG, where the icon links to the GitHub repo, and the number of stars links to the stargazers list. I decided against it as an image is simpler to layout and more control over the link. This might be a precaution if the shields service should be hacked.
