### PR TITLE
Add instructions to the Security Policy for automated scanners

### DIFF
--- a/pages/security.ftl
+++ b/pages/security.ftl
@@ -11,11 +11,15 @@
 
     <p>It is important that suspected vulnerabilities are disclosed in a responsible way, and are not publicly disclosed until after they have been analysed and a fix is available.</p>
 
-    <p>To report a security vulnerability in the Keycloak codebase, send an email to <a href="mailto:keycloak-security@googlegroups.com">keycloak-security@googlegroups.com</a>. Please include the version affected, provide detailed instructions on how to reproduce the issue, and include your contact information for acknowledgements. If you are reporting known CVEs related to third-party libraries used in Keycloak, please <a href="https://github.com/keycloak/keycloak/issues/new/choose">create a new GitHub issue</a>.</p>
+    <p>To report a security vulnerability in the Keycloak codebase, send an email to <a href="mailto:keycloak-security@googlegroups.com">keycloak-security@googlegroups.com</a>. Please test against the <b>latest version</b> of Keycloak and include the version affected in your report, provide detailed instructions on how to reproduce the issue with a <a href="https://stackoverflow.com/help/minimal-reproducible-example">minimal an reproducible example</a>, and include your contact information for acknowledgements. If you are reporting known CVEs related to third-party libraries used in Keycloak, please <a href="https://github.com/keycloak/keycloak/issues/new/choose">create a new GitHub issue</a>.</p>
 
     <p>If you would like to work with us on a fix for the security vulnerability, please include your GitHub username in the above email, and we will provide you access to a temporary private fork where we can collaborate on a fix without it being disclosed publicly.</p>
 
     <p>Do not open a public issue, send a pull request, or disclose any information about the suspected vulnerability publicly. If you discover any publicly disclosed security vulnerabilities, please notify us immediately through <a href="mailto:keycloak-security@googlegroups.com">keycloak-security@googlegroups.com</a>.</p>
+
+    <h2>Security Scanners</h2>
+
+    <p>Reports from automated security scanners will <b>not<b> be accepted. These tools often report false positives, and can be disruptive to the project maintainers as it takes a long time to analyse these reports. If you believe you have found a security vulnerability using a security scanner, it is your responsiblity to provide a clear example of the vulnerability and how it could be exploited specifically for Keycloak as outlined above.</p>
 
     <h2>Supported Versions</h2>
 


### PR DESCRIPTION
Adds a new section to the 'Security Policy' page outlining the requirements for reporting security issues from automated security scanners, specifically the need to provide a minimal and reproducible example specifically for Keycloak that can actually be exploited.

This also refines the section on reporting issues in general to emphasize the need to test against the latest stable version of Keycloak, as well as the need to provide a minimal an reproducible example.