### PR TITLE
Move saml documentation to guides

### DIFF
--- a/guides/securing-apps/apisix.adoc
+++ b/guides/securing-apps/apisix.adoc
@@ -1,3 +1,0 @@
-:guide-title: Apache APISIX
-:guide-summary: Integrate Keycloak for Authentication with Apache APISIX
-:external-link: https://apisix.apache.org/blog/2021/12/10/integrate-keycloak-auth-in-apisix

--- a/guides/securing-apps/krakend.adoc
+++ b/guides/securing-apps/krakend.adoc
@@ -1,3 +1,0 @@
-:guide-title: KrakenD
-:guide-summary: Secure APIs with an API Gateway
-:external-link: https://www.krakend.io/docs/authorization/keycloak/

--- a/guides/securing-apps/quarkus.adoc
+++ b/guides/securing-apps/quarkus.adoc
@@ -1,3 +1,0 @@
-:guide-title: Quarkus
-:guide-summary: Using OpenID Connect and Keycloak to secure your Quarkus applications
-:external-link: https://quarkus.io/guides/security-keycloak-authorization

--- a/guides/securing-apps/traefik-hub.adoc
+++ b/guides/securing-apps/traefik-hub.adoc
@@ -1,3 +1,0 @@
-:guide-title: Traefik Hub
-:guide-summary: Use Keycloak as an identity provider or as an identity broker for Traefik Hub API management
-:external-link: https://doc.traefik.io/traefik-hub/authentication-authorization/idp/keycloak

--- a/guides/securing-apps/wildfly.adoc
+++ b/guides/securing-apps/wildfly.adoc
@@ -1,3 +1,0 @@
-:guide-title: WildFly
-:guide-summary: Secure WildFly Applications with Keycloak
-:external-link: https://wildfly-security.github.io/wildfly-elytron/blog/securing-wildfly-apps-openid-connect/

--- a/src/main/java/org/keycloak/webbuilder/Guides.java
+++ b/src/main/java/org/keycloak/webbuilder/Guides.java
@@ -34,6 +34,7 @@ public class Guides {
             try {
                 loadGuides(asciiDoctor, new File(f, "generated-guides/server"), GuideCategory.SERVER);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/operator"), GuideCategory.OPERATOR);
+                loadGuides(asciiDoctor, new File(f, "generated-guides/securing-apps"), GuideCategory.SECURING_APPS);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/migration"), GuideCategory.MIGRATION);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/getting-started"), GuideCategory.GETTING_STARTED);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/high-availability"), GuideCategory.HIGH_AVAILABILITY);


### PR DESCRIPTION
Closes #31330

Little changes needed with keycloak PR https://github.com/keycloak/keycloak/pull/31472 to create the new `securing-apps` section in the guides. Sending as draft for now.