### PR TITLE
Changes to add securing-apps guides in keycloak

### DIFF
--- a/src/main/java/org/keycloak/webbuilder/Guides.java
+++ b/src/main/java/org/keycloak/webbuilder/Guides.java
@@ -36,6 +36,7 @@ public class Guides {
                 loadGuides(asciiDoctor, new File(f, "generated-guides/operator"), GuideCategory.OPERATOR);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/migration"), GuideCategory.MIGRATION);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/getting-started"), GuideCategory.GETTING_STARTED);
+                loadGuides(asciiDoctor, new File(f, "generated-guides/securing-apps"), GuideCategory.SECURING_APPS);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/high-availability"), GuideCategory.HIGH_AVAILABILITY);
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Closes keycloak/keycloak#31569

Adding the line to also add into `securing-apps` the guides in keycloak. I have checked that with current version the external guides are present, and using `-Dversion.keycloak=999.0.0-SNAPSHOT` both external and the ones in keycloak are there.