### PR TITLE
Adding keycloak-client guides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <version.commons-compress>1.26.0</version.commons-compress>
 
         <version.keycloak>25.0.2</version.keycloak>
+        <version.keycloak.client>26.0.0-SNAPSHOT</version.keycloak.client>
 
         <version.frontend-maven-plugin>1.12.1</version.frontend-maven-plugin>
         <version.node>v16.13.1</version.node>
@@ -213,6 +214,15 @@
                                             <groupId>org.keycloak</groupId>
                                             <artifactId>keycloak-guides</artifactId>
                                             <version>${version.keycloak}</version>
+                                            <classifier>asciidoc</classifier>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.keycloak</groupId>
+                                            <artifactId>keycloak-client-guides</artifactId>
+                                            <version>${version.keycloak.client}</version>
                                             <classifier>asciidoc</classifier>
                                             <type>zip</type>
                                             <overWrite>true</overWrite>

--- a/src/main/java/org/keycloak/webbuilder/Guides.java
+++ b/src/main/java/org/keycloak/webbuilder/Guides.java
@@ -30,7 +30,8 @@ public class Guides {
             loadGuides(asciiDoctor, d, category);
         }
 
-        Arrays.stream(tmpDir.getParentFile().listFiles((f, s) -> s.startsWith("keycloak-guides"))).findFirst().ifPresent(f -> {
+        Arrays.stream(tmpDir.getParentFile().listFiles((f, s) -> s.startsWith("keycloak-guides") || s.startsWith("keycloak-client-guides")))
+                .forEach(f -> {
             try {
                 loadGuides(asciiDoctor, new File(f, "generated-guides/server"), GuideCategory.SERVER);
                 loadGuides(asciiDoctor, new File(f, "generated-guides/operator"), GuideCategory.OPERATOR);
@@ -238,9 +239,9 @@ public class Guides {
         SECURING_APPS("securing-apps", "Securing applications"),
         HIGH_AVAILABILITY("high-availability", "High availability");
 
-        private String label;
+        private final String label;
 
-        private String id;
+        private final String id;
 
         GuideCategory(String id, String label) {
             this.id = id;

--- a/src/main/java/org/keycloak/webbuilder/builders/ResourcesBuilder.java
+++ b/src/main/java/org/keycloak/webbuilder/builders/ResourcesBuilder.java
@@ -4,11 +4,9 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ResourcesBuilder extends AbstractBuilder {
 
@@ -23,17 +21,19 @@ public class ResourcesBuilder extends AbstractBuilder {
 
         FileUtils.copyDirectory(new File(context.getBlogDir(), "images"), new File(new File(targetResourcesDir, "images"), "blog"));
         FileUtils.copyDirectory(new File(context.getGuidesDir(), "images"), guidesImageDir);
-        Optional<File> genGuidesDir = Arrays.stream(context.getTmpDir().getParentFile().listFiles((f, s) -> s.startsWith("keycloak-guides"))).findFirst();
+        List<File> genGuidesImagesDirs = Arrays.stream(context.getTmpDir().getParentFile()
+                .listFiles((f, s) -> s.startsWith("keycloak-guides") || s.startsWith("keycloak-client-guides")))
+                .flatMap(d -> Arrays.stream(new File(d, "generated-guides").listFiles(n -> n.getName().equals("images"))))
+                .collect(Collectors.toList());
 
-        Optional<File> genGuidesImagesDir = genGuidesDir.flatMap( d -> Arrays.stream(new File(d, "generated-guides").listFiles(n -> n.getName().equals("images"))).findAny());
-        if (genGuidesImagesDir.isPresent()) {
-            for (File f : genGuidesImagesDir.get().listFiles()) {
-                if (f.isFile()) {
-                    FileUtils.copyFileToDirectory(f, guidesImageDir);
-                } else {
-                    FileUtils.copyDirectoryToDirectory(f, guidesImageDir);
-                }
-            }
+         for (File genGuidesImagesDir : genGuidesImagesDirs) {
+            for (File f : genGuidesImagesDir.listFiles()) {
+                 if (f.isFile()) {
+                     FileUtils.copyFileToDirectory(f, guidesImageDir);
+                 } else {
+                     FileUtils.copyDirectoryToDirectory(f, guidesImageDir);
+                 }
+             }
         }
 
         printStep("copied", "blog images");


### PR DESCRIPTION
Adding the guides for keycloak-client. Main changes:

* It needs to download the new `keycloak-client-guides` dependency to also obtain guides from that project.
* Images should also be retrieved from the new dependency.
* I'm setting the version of the client as a system property. We can do something fancier but I think this is OK (it's just to know the version of client used, nothing more).

This cannot be merged until we have a real keycloak-client release (if you see I'm using the snapshot version). So tests are gonna fail for sure. Maybe we can change the `add-version.sh` to receive the keycloak version and the keycloak-client version (or guess it from the dependency? Don't know if possible). Draft because it cannot be merged yet.

Check the PR in keycloak-client for images.

Related PRs:

* PR for keycloak-client: https://github.com/keycloak/keycloak-client/pull/28
* PR for keycloak: https://github.com/keycloak/keycloak/pull/32187

@stianst @mposolda Take a look when you have time. It's just a first idea. The sample images are in the keycloak-client PR.

