### PR TITLE
The client-auth extension was archived by its authors

### DIFF
--- a/extensions/client-authorization.json
+++ b/extensions/client-authorization.json
@@ -1,5 +1,0 @@
-{
-    "name": "Client Authorization",
-    "description": "Adds authorization capabilities to keycloak for a given client, whether the client itself has the capability to handle authorization or not.",
-    "website": "https://github.com/cloudtrust/keycloak-authorization"
-}


### PR DESCRIPTION
The [repository](https://github.com/cloudtrust/keycloak-authorization) states: "This repository has been archived by the owner on Jul 21, 2022. It is now read-only."

So I think it is time to remove it.

A replacement is probably https://github.com/sventorben/keycloak-restrict-client-auth which is already listed in the extensions as "restrict client auth": https://www.keycloak.org/extensions.html

