### PR TITLE
Redirect from old HA guide pages present in KC25 which are no longer available in KC26

### DIFF
--- a/static/high-availability/deploy-aws-route53-failover-lambda.html
+++ b/static/high-availability/deploy-aws-route53-failover-lambda.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting to introduction</title>
+    <meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/high-availability/introduction">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/high-availability/introduction">https://www.keycloak.org/high-availability/introduction</a>...
+</body>
+</html>

--- a/static/high-availability/deploy-aws-route53-loadbalancer.html
+++ b/static/high-availability/deploy-aws-route53-loadbalancer.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting to introduction</title>
+    <meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/high-availability/introduction">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/high-availability/introduction">https://www.keycloak.org/high-availability/introduction</a>...
+</body>
+</html>

--- a/static/high-availability/operate-failover.html
+++ b/static/high-availability/operate-failover.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting to introduction</title>
+    <meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/high-availability/introduction">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/high-availability/introduction">https://www.keycloak.org/high-availability/introduction</a>...
+</body>
+</html>

--- a/static/high-availability/operate-network-partition-recovery.html
+++ b/static/high-availability/operate-network-partition-recovery.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting to introduction</title>
+    <meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/high-availability/introduction">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/high-availability/introduction">https://www.keycloak.org/high-availability/introduction</a>...
+</body>
+</html>

--- a/static/high-availability/operate-switch-back.html
+++ b/static/high-availability/operate-switch-back.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting to introduction</title>
+    <meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/high-availability/introduction">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/high-availability/introduction">https://www.keycloak.org/high-availability/introduction</a>...
+</body>
+</html>

--- a/static/high-availability/operate-switch-over.html
+++ b/static/high-availability/operate-switch-over.html
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting to introduction</title>
+    <meta http-equiv="refresh" content="0; URL=https://www.keycloak.org/high-availability/introduction">
+</head>
+<body>
+Redirecting to <a href="https://www.keycloak.org/high-availability/introduction">https://www.keycloak.org/high-availability/introduction</a>...
+</body>
+</html>


### PR DESCRIPTION
Do not merge until KC26 has been released.

Closes https://github.com/keycloak/keycloak/issues/31837