### PR TITLE
Add community-extension: BundID IDP integration

### DIFF
--- a/extensions/bundid.json
+++ b/extensions/bundid.json
@@ -1,0 +1,5 @@
+{
+  "name": "BundID Integration",
+  "description": "Integrate German BundID identity provider (https://id.bund.de) including support for attribute requests and mapping of STORK QAA levels.",
+  "website": "https://github.com/opdt/keycloak-extension-bundid"
+}


### PR DESCRIPTION
This extension was open sourced because a lot of german organizations need to integrate german federal IDP "BundID", which is actually not that trivial (because of some non-standard parts of BundID specification).