### PR TITLE
Downloads page has wrong Keycloak Javascript Adapter artifacts file names generated

### DIFF
--- a/templates/downloads-211.ftl
+++ b/templates/downloads-211.ftl
@@ -18,7 +18,7 @@
 </span>
 </#if>
 <#if tgz>
-<span>
+        <span>
 <a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tgz" target="_blank">
     <i class="fa fa-download" aria-hidden="true"></i>
     TGZ
@@ -114,6 +114,32 @@
         <div role="tabpanel" class="tab-pane active margin-top" id="oidc">
             <table class="table table-bordered table-striped">
                 <tr>
+                    <td>WildFly <b>[DEPRECATED]</b></td>
+                    <td>
+                        <table class="kc-table-downloads-inner">
+                            <tr>
+                                <td>&lt;= 23</td>
+                                <td>
+                                    <@download category="adapter" label="wildfly" file="keycloak-oidc-wildfly-adapter-${version.version}" tar=true />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td>JBoss EAP <b>[DEPRECATED]</b></td>
+                    <td>
+                        <table class="kc-table-downloads-inner">
+                            <tr>
+                                <td>7</td>
+                                <td>
+                                    <@download category="adapter" label="eap7" file="keycloak-oidc-wildfly-adapter-${version.version}" tar=true />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
                     <td>JavaScript</td>
                     <td>
                         <table class="kc-table-downloads-inner">
@@ -179,6 +205,34 @@
         <div role="tabpanel" class="tab-pane margin-top" id="saml">
             <table class="table table-bordered table-striped">
                 <tbody>
+                <tr>
+                    <td>WildFly</td>
+                    <td>
+                        <table class="kc-table-downloads-inner">
+                            <tr>
+                                <td>
+                                    &lt;= 23
+                                </td>
+                                <td>
+                                    <@download category="adapter-saml" label="wildfly" file="keycloak-saml-wildfly-adapter-${version.version}" tar=true />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td>JBoss EAP</td>
+                    <td>
+                        <table class="kc-table-downloads-inner">
+                            <tr>
+                                <td>7</td>
+                                <td>
+                                    <@download category="adapter-saml" label="eap7" file="keycloak-saml-wildfly-adapter-${version.version}" tar=true />
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
                 <tr>
                     <td>Jetty <b>[DEPRECATED]</b></td>
                     <td>

--- a/templates/downloads-23.ftl
+++ b/templates/downloads-23.ftl
@@ -1,4 +1,4 @@
-<#macro download category label file tar=true zip=true>
+<#macro download category label file tar=true zip=true tgz=false>
 <#if zip>
 <span class="me-4">
 <a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.zip" target="_blank">
@@ -15,6 +15,14 @@
     TAR.GZ
 </a>
 (<a href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tar.gz.sha1" target="_blank">sha1</a>)
+</span>
+</#if>
+<#if tgz>
+<span>
+<a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tgz" target="_blank">
+    <i class="fa fa-download" aria-hidden="true"></i>
+    TGZ
+</a>
 </span>
 </#if>
 </#macro>
@@ -117,7 +125,7 @@
                                         <i class="fa fa-link"></i> NPM
                                     </a>
                                     </span>
-                                    <@download category="adapter" label="js" file="keycloak-oidc-js-adapter-${version.version}" tar=true />
+                                    <@download category="adapter" label="js" file="keycloak-js-${version.version}" zip=false tar=false tgz=true />
                                 </td>
                             </tr>
                         </table>

--- a/templates/downloads-24.ftl
+++ b/templates/downloads-24.ftl
@@ -1,4 +1,4 @@
-<#macro download category label file tar=true zip=true>
+<#macro download category label file tar=true zip=true tgz=false>
 <#if zip>
 <span class="me-4">
 <a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.zip" target="_blank">
@@ -15,6 +15,14 @@
     TAR.GZ
 </a>
 (<a href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tar.gz.sha1" target="_blank">sha1</a>)
+</span>
+</#if>
+<#if tgz>
+<span>
+<a onclick="dl('${category}', '${label}');" href="https://github.com/keycloak/keycloak/releases/download/${version.version}/${file}.tgz" target="_blank">
+    <i class="fa fa-download" aria-hidden="true"></i>
+    TGZ
+</a>
 </span>
 </#if>
 </#macro>
@@ -113,7 +121,7 @@
                                         <i class="fa fa-link"></i> NPM
                                     </a>
                                     </span>
-                                    <@download category="adapter" label="js" file="keycloak-oidc-js-adapter-${version.version}" tar=true />
+                                    <@download category="adapter" label="js" file="keycloak-js-${version.version}" zip=false tar=false tgz=true />
                                 </td>
                             </tr>
                         </table>

--- a/versions/keycloak/21.1.0.json
+++ b/versions/keycloak/21.1.0.json
@@ -3,5 +3,5 @@
   "version": "21.1.0",
   "blogTemplate": 2,  
   "documentationTemplate": 11,
-  "downloadTemplate": 21
+  "downloadTemplate": 211
 }

--- a/versions/keycloak/21.1.1.json
+++ b/versions/keycloak/21.1.1.json
@@ -3,5 +3,5 @@
   "version": "21.1.1",
   "blogTemplate": 2,  
   "documentationTemplate": 11,
-  "downloadTemplate": 21
+  "downloadTemplate": 211
 }

--- a/versions/keycloak/21.1.2.json
+++ b/versions/keycloak/21.1.2.json
@@ -3,5 +3,5 @@
   "version": "21.1.2",
   "blogTemplate": 2,  
   "documentationTemplate": 11,
-  "downloadTemplate": 21
+  "downloadTemplate": 211
 }


### PR DESCRIPTION
Downloads page has wrong Keycloak Javascript Adapter artifacts file names generated

> Note: SHA1 checksums are not generated, but it has to be fixed on different repository.

Closes #512