### PR TITLE
Add community meeting information to community.ftl

### DIFF
--- a/pages/community.ftl
+++ b/pages/community.ftl
@@ -16,6 +16,18 @@
     </div>
 
     <div class="row mt-3">
+        <h2>Community meetings</h2>
+        <ul class="ms-4">
+            <li>OAuth SIG Monthly meeting</li>
+            <ul>
+                <li>Time: Wed 12:00 PM - 01:00 PM London</li>
+                <li>Zoom Link: <a href="https://zoom.us/j/93447076633">https://zoom.us/j/93447076633</a></li>
+                <li>For more details about the meeting check out the <a href="https://github.com/keycloak/kc-sig-fapi">GitHub repository</a> and <a href="https://cloud-native.slack.com/archives/C05KR0TL4P8">Slack channel</a>.</li>
+            </ul>
+        </ul>
+    </div>
+
+    <div class="row mt-3">
         <h2>Extensions</h2>
         <p>You can find a number of community maintained extensions to Keycloak <a href="extensions.html">here</a>
     </div>


### PR DESCRIPTION
In response to [this comment](https://github.com/keycloak/keycloak/pull/32385#pullrequestreview-2359572507), I created a PR to post community meeting information on the community site.
And I added the OAuth SIG Monthly meeting information.
@stianst 