### PR TITLE
Add external claim mapper extension to extensions page

### DIFF
--- a/extensions/keycloak-external-claim-mapper.json
+++ b/extensions/keycloak-external-claim-mapper.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keycloak External Claim Mapper",
+  "description": "Implementation of the keycloak internal SPI protocol-mapper, that allows to fetch remote http json data, transform and include it into user JWT.",
+  "website": "https://github.com/zloom/keycloak-external-claim-mapper"
+}


### PR DESCRIPTION
Hello, keycloak maintainers!

I developed extension and would like to propose to include it to https://www.keycloak.org/extensions. It is almost same as https://github.com/groupe-sii/keycloak-json-remote-claim
I made couple of improvements.
- Added user token auth, jsonpath transform and some other configurations, including all features from JSON Remote claim Mapper for Keycloak
- Tested with last keycloak release 25.0.0
- Repository contains all test tools including remote api stub, that helped me alot during debugging my keycloak integration.

I was really enjoying using keycloak in my projects, so i would like to contribute to it. Please take a look. 


