### PR TITLE
Upgrade keycloak-client-guides to 26.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <version.commons-compress>1.26.0</version.commons-compress>
 
         <version.keycloak>26.0.2</version.keycloak>
-        <version.keycloak.client>26.0.0</version.keycloak.client>
+        <version.keycloak.client>26.0.1</version.keycloak.client>
 
         <version.frontend-maven-plugin>1.12.1</version.frontend-maven-plugin>
         <version.node>v16.13.1</version.node>


### PR DESCRIPTION
Closes #524

Adding last version of keycloak client to generate the latest guides.