### PR TITLE
Add community-extension: MFA Plugin Collection

### DIFF
--- a/extensions/keycloak-mfa-plugins.json
+++ b/extensions/keycloak-mfa-plugins.json
@@ -1,0 +1,5 @@
+{
+  "name": "MFA Plugin collection",
+  "description": "A collection of MFA plugins: SMS authenticator, Enforce MFA, Native App MFA integration.",
+  "website": "https://github.com/netzbegruenung/keycloak-mfa-plugins"
+}


### PR DESCRIPTION
Hello Keycloak Team,

Our organization would like to share a collection of MFA extensions with the Keycloak community. We're excited to contribute and would appreciate any feedback you may have.

The project includes three extensions:

- SMS Authenticator: An implementation of the Authenticator SPI for SMS-based MFA, inspired by [dasniko’s 2FA SMS authenticator](https://github.com/dasniko/keycloak-2fa-sms-authenticator).
- Enforce MFA Authenticator: Supports the scenario where users authenticate with a second factor. If neither is available, the user can choose to register one. Based on [this Keycloak PR](https://github.com/keycloak/keycloak/pull/17494).
- Native App MFA Integration: Enables a dedicated mobile app as an MFA method, inspired by the [Action Token Authenticator example](https://github.com/keycloak/keycloak-quickstarts/tree/latest/extension/action-token-authenticator).

We would be thrilled to have our extensions included in the official Keycloak extensions listing. Thank you for considering this!