### PR TITLE
Add community extension Keycloak OpenFGA Event Publisher

### DIFF
--- a/extensions/keycloak-openfga-event-publisher.json
+++ b/extensions/keycloak-openfga-event-publisher.json
@@ -1,5 +1,5 @@
 {
-    "name": "Keycloak OpenFGA Event Publisher",
+    "name": "OpenFGA Event Publisher",
     "description": "Keycloak extension enables event integration between Keycloak and OpenFGA for Fine-Grained Authorization (FGA).",
     "website": "https://github.com/embesozzi/keycloak-openfga-event-publisher"
   }

--- a/extensions/keycloak-openfga-event-publisher.json
+++ b/extensions/keycloak-openfga-event-publisher.json
@@ -1,0 +1,5 @@
+{
+    "name": "Keycloak OpenFGA Event Publisher",
+    "description": "Keycloak extension enables event integration between Keycloak and OpenFGA for Fine-Grained Authorization (FGA).",
+    "website": "https://github.com/embesozzi/keycloak-openfga-event-publisher"
+  }


### PR DESCRIPTION
Hello Keycloak maintainers,

I would like to contribute a Keycloak extension that helps synchronize events from Keycloak to the [OpenFGA](https://github.com/openfga) platform. Using this extension, I have also created the following workshop and articles (detailed below) to provide examples of how to transition from traditional authorization models like RBAC or GBAC to ReBAC for Fine-Grained Authorization (FGA).

- [Workshop: Keycloak integration with OpenFGA for Fine-Grained Authorization at Scale (ReBAC)](https://github.com/embesozzi/keycloak-openfga-workshop)
- [Article: Keycloak integration with OpenFGA (based on Zanzibar) for Fine-Grained Authorization at Scale (ReBAC)](https://embesozzi.medium.com/keycloak-integration-with-openfga-based-on-zanzibar-for-fine-grained-authorization-at-scale-d3376de00f9a)
- [Article: Mastering Access Control: Low-Code Authorization with ReBAC, Decoupling Patterns and Policy as Code](https://medium.com/@embesozzi/mastering-access-control-implementing-low-code-authorization-based-on-rebac-and-decoupling-pattern-f6f54f70115e)

It would be great to have our extension included in the official Keycloak extensions listing.
