### PR TITLE
Add Observability guides category and make sure empty categories are …

### DIFF
--- a/guides.yaml
+++ b/guides.yaml
@@ -7,6 +7,8 @@ guides:
     title: Server
   - id: operator
     title: Operator
+  - id: observability
+    title: Observability
   - id: securing-apps
     title: Securing applications
   - id: high-availability

--- a/pages/guides.ftl
+++ b/pages/guides.ftl
@@ -7,7 +7,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
         <ul class="nav navbar-nav">
-            <#list guides.categories as c>
+            <#list guides.getCategories(false) as c>
             <li>
                 <a class="nav-link" href="#${c.id}">${c.title}</a>
             </li>
@@ -23,7 +23,7 @@
 
 <div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-4">
     <div class="container">
-        <#list guides.categories as c>
+        <#list guides.getCategories(false) as c>
             <div class="row guide-category" id="${c.id}">
                 <h2>${c.title}</h2>
                 <#list guides.getGuides(c) as g>

--- a/pages/nightly/guides.ftl
+++ b/pages/nightly/guides.ftl
@@ -7,7 +7,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
         <ul class="nav navbar-nav">
-            <#list guides.categories as c>
+            <#list guides.getCategories(true) as c>
             <li>
                 <a class="nav-link" href="#${c.id}">${c.title}</a>
             </li>
@@ -30,7 +30,7 @@
           These guides are for the unstable nightly release, for the latest release go <a href="${links.guides}">here</a>.
         </div>
 
-        <#list guides.categories as c>
+        <#list guides.getCategories(true) as c>
             <div class="row guide-category" id="${c.id}">
                 <h2>${c.title}</h2>
                 <#list guides.getGuides(c) as g>

--- a/src/main/java/org/keycloak/webbuilder/Guides.java
+++ b/src/main/java/org/keycloak/webbuilder/Guides.java
@@ -13,6 +13,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class Guides {
@@ -132,8 +133,12 @@ public class Guides {
         return guides;
     }
 
-    public List<GuidesMetadata.GuideMetadata> getCategories() {
-        return categories;
+    public List<GuidesMetadata.GuideMetadata> getCategories(boolean wantSnapshots) {
+        return categories.stream().filter(filterEmptyCategories(wantSnapshots)).collect(Collectors.toList());
+    }
+
+    private Predicate<GuidesMetadata.GuideMetadata> filterEmptyCategories(boolean wantSnapshots) {
+        return cat -> getGuides(cat).stream().anyMatch(guide-> guide.isSnapshot() == wantSnapshots);
     }
 
     public class Guide {


### PR DESCRIPTION
…not visible on guides page

Part-of: https://github.com/keycloak/keycloak/issues/35127

Here is the result:
![image](https://github.com/user-attachments/assets/fa3b8f5f-5f1d-4bda-964e-a428a68f698f)

Here are related changes in keycloak repository: https://github.com/keycloak/keycloak/pull/35144
