### PR TITLE
Consume keycloak-nodejs-connect guides

### DIFF
--- a/guides.yaml
+++ b/guides.yaml
@@ -24,3 +24,6 @@ sources:
   - id: keycloak-web
     dir: guides
     github: https://github.com/keycloak/keycloak-web/tree/main/guides/
+  - id: keycloak-nodejs-connect-guides
+    dir: target/keycloak-nodejs-connect-guides-$$VERSION$$
+    github: https://github.com/keycloak/keycloak-nodejs-connect/tree/main/guides/

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 
         <version.keycloak>26.1.0</version.keycloak>
         <version.keycloak.client>26.0.4</version.keycloak.client>
+        <version.keycloak-nodejs-connect>26.1.1</version.keycloak-nodejs-connect>
 
         <version.frontend-maven-plugin>1.12.1</version.frontend-maven-plugin>
         <version.node>v16.13.1</version.node>
@@ -31,6 +32,7 @@
         <version.maven-jar-plugin>3.1.2</version.maven-jar-plugin>
         <version.exec-maven-plugin>3.0.0</version.exec-maven-plugin>
         <version.dependency-plugin>3.1.2</version.dependency-plugin>
+        <version.download-maven-plugin>2.0.0</version.download-maven-plugin>
     </properties>
 
     <repositories>
@@ -264,6 +266,37 @@
                                         </artifactItem>
                                     </artifactItems>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.github.download-maven-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>${version.download-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>unpack-keycloak-nodejs-connect-nightly</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://github.com/keycloak/keycloak-nodejs-connect/releases/download/nightly/keycloak-nodejs-connect-guides.zip</url>
+                                    <unpack>true</unpack>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+	                        </configuration>
+                            </execution>
+                            <execution>
+                                <id>unpack-keycloak-nodejs-connect-version</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://github.com/keycloak/keycloak-nodejs-connect/releases/download/${version.keycloak-nodejs-connect}/keycloak-nodejs-connect-guides.zip</url>
+                                    <unpack>true</unpack>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+	                        </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Closes #550

Draft to download and unzip the `keycloak-nodejs-connect` guides into the target directory and add those guides for the generation in the web. It uses the `download-maven-plugin` to do that. It's a draft because a final release in the `keycloak-nodejs-connect` is needed with the guides zip. Right now it is using `nightly` but I think this is not OK either because keycloak-rel is also creating a nightly tag without the guides zip.