### PR TITLE
Fixing the link to securing application guide

### DIFF
--- a/version-template.json
+++ b/version-template.json
@@ -2,6 +2,6 @@
   "date": "DATE",
   "version": "VERSION",
   "blogTemplate": 3,
-  "documentationTemplate": 11,
+  "documentationTemplate": 12,
   "downloadTemplate": 24
 }

--- a/versions/26.1.0.json
+++ b/versions/26.1.0.json
@@ -2,6 +2,6 @@
   "date": "2025-01-15",
   "version": "26.1.0",
   "blogTemplate": 3,
-  "documentationTemplate": 11,
+  "documentationTemplate": 12,
   "downloadTemplate": 24
 }


### PR DESCRIPTION
It is currently broken here: https://www.keycloak.org/documentation