### PR TITLE
Consume keycloak-js-guides.zip in keycloak-web

### DIFF
--- a/guides.yaml
+++ b/guides.yaml
@@ -27,3 +27,6 @@ sources:
   - id: keycloak-nodejs-connect-guides
     dir: target/keycloak-nodejs-connect-guides-$$VERSION$$
     github: https://github.com/keycloak/keycloak-nodejs-connect/tree/main/guides/
+  - id: keycloak-js-guides
+    dir: target/keycloak-js-guides-$$VERSION$$
+    github: https://github.com/keycloak/keycloak-js/tree/main/docs/guides/

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <version.keycloak>26.1.2</version.keycloak>
         <version.keycloak-client>26.0.4</version.keycloak-client>
         <version.keycloak-nodejs-connect>26.1.1</version.keycloak-nodejs-connect>
+        <version.keycloak-js>26.2.0</version.keycloak-js>
 
         <version.frontend-maven-plugin>1.12.1</version.frontend-maven-plugin>
         <version.node>v16.13.1</version.node>
@@ -300,6 +301,30 @@
                                 </goals>
                                 <configuration>
                                     <url>https://github.com/keycloak/keycloak-nodejs-connect/releases/download/${version.keycloak-nodejs-connect}/keycloak-nodejs-connect-guides.zip</url>
+                                    <unpack>true</unpack>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+	                        </configuration>
+                            </execution>
+                            <execution>
+                                <id>unpack-keycloak-js-nightly</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://github.com/keycloak/keycloak-js/releases/download/nightly/keycloak-js-guides.zip</url>
+                                    <unpack>true</unpack>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+	                        </configuration>
+                            </execution>
+                            <execution>
+                                <id>unpack-keycloak-js-version</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://github.com/keycloak/keycloak-js/releases/download/${version.keycloak-js}/keycloak-js-guides.zip</url>
                                     <unpack>true</unpack>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
 	                        </configuration>


### PR DESCRIPTION
Closes #554

Just adding the keycloak-js guides to be consumed from the github release. For the moment a draft because we need to wait to have a available current version. For the moment the current version is also nitly to test it is downloaded and used OK.