### PR TITLE
Remove archived community extensions

### DIFF
--- a/extensions/export-endpoint.json
+++ b/extensions/export-endpoint.json
@@ -1,5 +1,0 @@
-{
-    "name": "Full export endpoint",
-    "description": "Provides an endpoint allowing the full export of a realm, without having to restart keycloak.",
-    "website": "https://github.com/cloudtrust/keycloak-export"
-}

--- a/extensions/keycloak-connect-graphql.json
+++ b/extensions/keycloak-connect-graphql.json
@@ -1,5 +1,0 @@
-{
-  "name": "Express.js GraphQL",
-  "description": "Add Keyloak Authentication and Authorization to your GraphQL server.",
-  "website": "https://github.com/aerogear/keycloak-connect-graphql"
-}


### PR DESCRIPTION
These community extensions are archived and not relevant anymore. They should be removed from the list. 

@ahus1 Could you please check it? Thanks!