### PR TITLE
Add ranks to community extensions

### DIFF
--- a/pages/extensions.ftl
+++ b/pages/extensions.ftl
@@ -28,12 +28,23 @@
                             </div>
 
                             <#if extension.stars??>
-                                <div class="card-footer text-muted">
+                                <div class="card-footer text-muted d-flex justify-content-between align-items-center">
                                     <div class="d-flex align-items-center">
                                         <img src="resources/images/github.png" width="16px" alt="GitHub logo"
                                              class="me-2"/>
-                                        <span>${extension.stars} stars</span>
+                                        <span>${extension.printStars()} stars</span>
                                     </div>
+                                    <#if extension.rank??>
+                                        <div style="font-size: 20px; line-height: 25px;">
+                                            <#if extension.rank == 1>
+                                                &#129351; <!-- Gold Medal -->
+                                            <#elseif extension.rank == 2>
+                                                &#129352; <!-- Silver Medal -->
+                                            <#elseif extension.rank == 3>
+                                                &#129353; <!-- Bronze Medal -->
+                                            </#if>
+                                        </div>
+                                    </#if>
                                 </div>
                             </#if>
                         </div>

--- a/src/main/java/org/keycloak/webbuilder/Extensions.java
+++ b/src/main/java/org/keycloak/webbuilder/Extensions.java
@@ -66,7 +66,7 @@ public class Extensions {
                     if (StringUtils.isNotEmpty(repoName)) {
                         var repository = gh.getRepository(repoName);
                         if (repository != null) {
-                            extension.setStars(getFormattedStarsCount(repository.getStargazersCount()));
+                            extension.setStars(repository.getStargazersCount());
                             updatedAt = repository.getPushedAt();
                         }
                     }
@@ -80,6 +80,21 @@ public class Extensions {
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+
+        setTopExtensions();
+    }
+
+    private void setTopExtensions() {
+        List<Extension> topExtensions = extensionsMap.get(LivenessCategory.ACTIVE)
+                .stream()
+                .filter(f -> f.getStars() != null)
+                .sorted(Comparator.comparingInt(Extension::getStars).reversed())
+                .limit(3)
+                .toList();
+
+        for (int i = 0; i < topExtensions.size(); i++) {
+            topExtensions.get(i).setRank(i + 1);
         }
     }
 
@@ -101,7 +116,9 @@ public class Extensions {
         private String documentation;
         private String source;
 
-        private String stars;
+        private Integer stars;
+
+        private Integer rank;
 
         public String getName() {
             return name;
@@ -159,12 +176,24 @@ public class Extensions {
             this.source = source;
         }
 
-        public String getStars() {
+        public Integer getStars() {
             return stars;
         }
 
-        public void setStars(String stars) {
+        public String printStars() {
+            return getFormattedStarsCount(getStars());
+        }
+
+        public void setStars(Integer stars) {
             this.stars = stars;
+        }
+
+        public Integer getRank() {
+            return rank;
+        }
+
+        public void setRank(Integer rank) {
+            this.rank = rank;
         }
 
         @Override


### PR DESCRIPTION
We can move things even further as the community extensions might have ranks based on popularity :P 

It might involve more users and extension creators visiting the website to have it more gamified :video_game: 


https://github.com/user-attachments/assets/638c6fd6-1d0c-4f10-aa75-d7a389c8062f

@ahus Could you please check it once you have the time? Thanks!

