### PR TITLE
Low resolution background image in guides

### DIFF
--- a/pages/extensions.ftl
+++ b/pages/extensions.ftl
@@ -2,7 +2,7 @@
 
 <@tmpl.page current="extensions" title="Extensions" previewImage="extensions.png" summary="Use community maintained extensions to extend the functionality of your Keycloak setup.">
 
-<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-4">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles kc-bg-fixed pt-4">
     <div class="container">
         <h1 class="text-white">Extensions</h1>
 

--- a/pages/guides.ftl
+++ b/pages/guides.ftl
@@ -21,10 +21,10 @@
     </div>
 </nav>
 
-<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-4">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles kc-bg-fixed pt-4 pb-1">
     <div class="container">
         <#list guides.getCategories(false) as c>
-            <div class="row guide-category" id="${c.id}">
+            <div class="row guide-category mb-4" id="${c.id}">
                 <h2>${c.title}</h2>
                 <#list guides.getGuides(c) as g>
                 <#if g.tileVisible && !g.snapshot>

--- a/pages/nightly/guides.ftl
+++ b/pages/nightly/guides.ftl
@@ -21,7 +21,7 @@
     </div>
 </nav>
 
-<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles pt-4">
+<div class="jumbotron jumbotron-fluid bg-light kc-bg-triangles kc-bg-fixed pt-4 pb-1">
 
     <div class="container">
         <div class="alert alert-warning" role="alert">
@@ -31,7 +31,7 @@
         </div>
 
         <#list guides.getCategories(true) as c>
-            <div class="row guide-category" id="${c.id}">
+            <div class="row guide-category mb-4" id="${c.id}">
                 <h2>${c.title}</h2>
                 <#list guides.getGuides(c) as g>
                 <#if g.tileVisible && g.snapshot>

--- a/resources/css/keycloak.css
+++ b/resources/css/keycloak.css
@@ -29,6 +29,10 @@
     background-size: cover;
 }
 
+.kc-bg-fixed {
+    background-attachment: fixed;
+}
+
 .btn-primary {
     color: #fff;
     background-color: #428bca;
@@ -146,6 +150,12 @@ a:hover {
 }
 
 /* Guide - Options */
+
+.guide-category {
+    border-radius: 0.5rem;
+    background-color: #EDEDED99;
+    padding: 1rem 0.5rem 0;
+}
 
 table.options {
     width: 100%;


### PR DESCRIPTION
Closes #581

Proposed changes:

- Let the background in the guides section to be fixed to the screen
- For better readability and categorization, added a block containing all guides in the category

PS: it might be even nice to increase border radius for all buttons, labels and even these categories for some time to show to current visitors some action as the project is still alive :P IMO, it has some psychological effect 

Before: 

https://github.com/user-attachments/assets/93cc0495-7734-4586-aa7c-6cc871df0a49

After:

https://github.com/user-attachments/assets/97d05f29-5a71-44f3-9cbe-d1a2a515ce09

### Extensions page
#### OLD
![image](https://github.com/user-attachments/assets/46977e94-ecbf-45dd-992e-9e4ffa99ba55)

#### NEW
![image](https://github.com/user-attachments/assets/0b1fd910-5069-4661-b16a-7c3497016532)

