### PR TITLE
Add TikTok IDP extension

### DIFF
--- a/extensions/tiktok-idp.json
+++ b/extensions/tiktok-idp.json
@@ -1,0 +1,5 @@
+{
+  "name": "TikTok Identity Provider",
+  "description": "Keycloak extension to add TikTok as an identity provider.",
+  "website": "https://github.com/mpowr-it/keycloak-tiktok"
+}


### PR DESCRIPTION
I have created a custom SPI to integrate TikTok as an IDP into Keycloak. It would be great to see it listed here.

See: https://github.com/mpowr-it/keycloak-tiktok