### PR TITLE
Include Keycloak App Passwords in extensions

### DIFF
--- a/extensions/keycloak-app-passwords.json
+++ b/extensions/keycloak-app-passwords.json
@@ -1,5 +1,5 @@
 {
     "name": "Keycloak App Passwords",
-    "description": "Generate app specific passwords in keycloak",
+    "description": "Generate app specific passwords in Keycloak",
     "website": "https://github.com/radicallyopensecurity/keycloak-app-passwords"
 }

--- a/extensions/keycloak-app-passwords.json
+++ b/extensions/keycloak-app-passwords.json
@@ -1,0 +1,5 @@
+{
+    "name": "Keycloak App Passwords",
+    "description": "Generate app specific passwords in keycloak",
+    "website": "https://github.com/radicallyopensecurity/keycloak-app-passwords"
+}


### PR DESCRIPTION
Adds keycloak-app-passwords extension to the extension list.

- Repo: https://github.com/radicallyopensecurity/keycloak-app-passwords

Fixes: https://github.com/keycloak/keycloak-web/issues/602