### PR TITLE
Keycloak Block Disposable Email Extension

### DIFF
--- a/extensions/keycloak-block-disposable-email.json
+++ b/extensions/keycloak-block-disposable-email.json
@@ -1,5 +1,5 @@
 {
   "name": "Block Disposable Email",
-  "description": "Prevent users from registering with disposable email addresses.",
+  "description": "Prevent users from registering with a disposable email addresses.",
   "website": "https://github.com/chintanbuch/keycloak-block-disposable-email"
 }


### PR DESCRIPTION
`Block Disposable Email` extension to the extension list.

Repo: https://github.com/chintanbuch/keycloak-block-disposable-email

Closes #618