### PR TITLE
Update keycloak-quickstarts download link

### DIFF
--- a/templates/downloads-21.ftl
+++ b/templates/downloads-21.ftl
@@ -83,7 +83,7 @@
             </a>
             </span>
             <span>
-            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/latest.zip" target="_blank">
+            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/main.zip" target="_blank">
                 <i class="fa fa-download" aria-hidden="true"></i>
                 ZIP
             </a>

--- a/templates/downloads-211.ftl
+++ b/templates/downloads-211.ftl
@@ -91,7 +91,7 @@
             </a>
             </span>
             <span>
-            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/latest.zip" target="_blank">
+            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/main.zip" target="_blank">
                 <i class="fa fa-download" aria-hidden="true"></i>
                 ZIP
             </a>

--- a/templates/downloads-22.ftl
+++ b/templates/downloads-22.ftl
@@ -91,7 +91,7 @@
             </a>
             </span>
             <span>
-            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/latest.zip" target="_blank">
+            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/main.zip" target="_blank">
                 <i class="fa fa-download" aria-hidden="true"></i>
                 ZIP
             </a>

--- a/templates/downloads-23.ftl
+++ b/templates/downloads-23.ftl
@@ -91,7 +91,7 @@
             </a>
             </span>
             <span>
-            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/latest.zip" target="_blank">
+            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/main.zip" target="_blank">
                 <i class="fa fa-download" aria-hidden="true"></i>
                 ZIP
             </a>

--- a/templates/downloads-24.ftl
+++ b/templates/downloads-24.ftl
@@ -103,7 +103,7 @@
             </a>
             </span>
             <span>
-            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/latest.zip" target="_blank">
+            <a onclick="dl('examples', 'quickstarts');" href="https://github.com/keycloak/keycloak-quickstarts/archive/main.zip" target="_blank">
                 <i class="fa fa-download" aria-hidden="true"></i>
                 ZIP
             </a>


### PR DESCRIPTION
Closes #621

The old link is for downloading the source code as a ZIP from the `latest` branch, so it can simply be updated to point to download the ZIP of the `main` branch source code (like clicking the "Code -> Download ZIP" button on the keycloak-quickstarts GitHub repo page with the `main` branch selected).