### PR TITLE
News section on frontpage not shown properly on smaller screens

### DIFF
--- a/pages/index.ftl
+++ b/pages/index.ftl
@@ -26,8 +26,8 @@
 
 <div class="jumbotron jumbotron-fluid bg-dark text-white">
 <div class="container bg-dark p-3">
-    <div class="row">
-        <div class="col-md-1 col-sm-12 fw-bold kc-news-item">News</div>
+    <div class="row kc-news-section">
+        <div class="col-md-1 col-sm-12 fw-bold justify-content-center kc-news-item">News</div>
         <#list news as n>
         <div class="col kc-news-item">
             <span class="badge bg-secondary">${n.date?string["dd MMM"]}</span> <a href="${n.link}">${n.title}</a>

--- a/resources/css/keycloak.css
+++ b/resources/css/keycloak.css
@@ -69,10 +69,18 @@ a:hover {
     display: flex;
     justify-content: center;
     align-items: center;
+    gap: .4rem;
 }
 
-.kc-news-item a{
-    margin-left: .4rem;
+@media only screen and (max-width: 768px) {
+    .kc-news-item {
+        justify-content: flex-start;
+        flex: 0 0 100%;
+    }
+
+    .kc-news-section {
+        gap: .8rem;
+    }
 }
 
 /* Articles */


### PR DESCRIPTION
- Closes #633
---------------------
For wide screens, the gap is used instead of the margin-left; no visible change.

### Small screens
### Old
<img width="398" height="223" alt="Screenshot From 2025-08-22 15-21-17" src="https://github.com/user-attachments/assets/000594da-3107-4afd-b577-76d486e8535a" />

### New
<img width="400" height="260" alt="Screenshot From 2025-09-01 15-45-07" src="https://github.com/user-attachments/assets/471564fd-2d0f-4932-8070-48ce11ba3383" />

@stianst Could you please check it? Thanks!
