### PR TITLE
Hide disruptive GH stars on small screens

### DIFF
--- a/templates/template.ftl
+++ b/templates/template.ftl
@@ -58,7 +58,6 @@
         <img style="aspect-ratio: 730/151" class="img-fluid" src="${links.getResource('images/logo.svg')}" width="240" alt="Keycloak"/>
     </a>
     <a class="nav-link d-none d-sm-block d-md-none d-lg-block" href="https://github.com/keycloak/keycloak"><img src="${links.getResource('images/stars-large.svg')}" style="height: 25px; aspect-ratio: ${projectStars.aspectRatioLarge}" alt="GitHub stars"/></a>
-    <a class="nav-link d-block d-sm-none d-md-block d-lg-none" href="https://github.com/keycloak/keycloak"><img src="${links.getResource('images/stars-small.svg')}" style="height: 25px; aspect-ratio: ${projectStars.aspectRatioSmall}" alt="GitHub stars"/></a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="fa fa-bars fa-lg px-1 py-2"></span>
     </button>
@@ -80,6 +79,9 @@
           <a class="nav-link <#if current = 'blog'>active</#if>" href="${links.blog}">Blog</a>
         </li>
       </ul>
+    </div>
+    <div class="d-block d-sm-none d-md-block d-lg-none text-center vw-100">
+        <a class="nav-link d-inline p-0" href="https://github.com/keycloak/keycloak"><img src="${links.getResource('images/stars-large.svg')}" style="height: 25px; aspect-ratio: ${projectStars.aspectRatioLarge}" alt="GitHub stars"/></a>
     </div>
 </nav>
 </header>


### PR DESCRIPTION
The count of GH stars on small screens (phones) looks very disruptive as the navbar's height is large and the kebab menu is floating somewhere down. 

It'd be good to remove the GH stars from the shown navbar header and rather to include it somewhere else. I'd say a nice place might be when opening the menu. 

## Closed menu
### Old
<img width="402" height="358" alt="Screenshot From 2025-09-01 16-25-39" src="https://github.com/user-attachments/assets/3b248475-5746-45e0-af50-3662efa199be" />

### New
<img width="398" height="349" alt="Screenshot From 2025-09-02 09-16-43" src="https://github.com/user-attachments/assets/2d7771e6-6397-4514-a094-ead1d8c8feb9" />


## Opened menu
### Old 
<img width="402" height="358" alt="Screenshot From 2025-09-01 16-25-43" src="https://github.com/user-attachments/assets/67f8836d-a484-4d4a-bfc1-1223be17d8bb" />

### New
<img width="398" height="349" alt="Screenshot From 2025-09-02 09-16-47" src="https://github.com/user-attachments/assets/f51bc7ba-843e-4e05-80c2-92cfb33dd4f9" />


@ahus1 @stianst Is it ok for you? 
