### PR TITLE
Add kcwarden to extension list

### DIFF
--- a/extensions/kcwarden.json
+++ b/extensions/kcwarden.json
@@ -1,0 +1,5 @@
+{
+  "name": "kcwarden - Keycloak Config Auditor",
+  "description": "Check your Keycloak realm configuration for common security issues.",
+  "website": "https://github.com/iteratec/kcwarden"
+}


### PR DESCRIPTION
As requested in https://github.com/iteratec/kcwarden/issues/83, I am suggesting to add [kcwarden](https://github.com/iteratec/kcwarden) to the list of extensions. 

Background: kcwarden is a Keycloak config auditor that checks your Keycloak realm configuration for security issues. You can also create custom rules to check for project-specific invariants ("the role `project-admin` should only be assigned to the Keycloak user group `admins`"), or even add completely custom scanner rules implemented in Python. [See the documentation](https://iteratec.github.io/kcwarden/) for more details (or attend our presentation at KeyConf on thursday ;) ).