### PR TITLE
Use lead for the Keycloak description on the main page

### DIFF
--- a/pages/index.ftl
+++ b/pages/index.ftl
@@ -8,7 +8,7 @@
         <div class="col">
             <h1 class="display-4 mb-0">Open Source</h1>
             <h1 class="display-3 fw-bold">Identity and Access Management</h1>
-            <p class="fs-5 mt-4">
+            <p class="lead mt-4">
                 Add authentication to applications and secure services with minimum effort.<br/>
                 No need to deal with storing users or authenticating users.
             </p>


### PR DESCRIPTION
The description text _Add authentication to applications and secure services with minimum effort. No need to deal with storing users or authenticating users._ looks **disruptive on the small screens** due to the text weight.

The better approach will be using the `lead` class as even Bootstrap [suggests](https://getbootstrap.com/docs/4.0/content/typography/#lead).

## Small screens
### Old
<img width="428" height="542" alt="Screenshot From 2025-09-01 15-58-19" src="https://github.com/user-attachments/assets/6c967ef2-819e-4008-a999-e7e83ee3ddc7" />

### New
<img width="428" height="542" alt="Screenshot From 2025-09-01 15-58-07" src="https://github.com/user-attachments/assets/0aa5df9e-1424-4499-ae86-a5e244c63fcc" />

## Wide screens
### Old
![old-wide](https://github.com/user-attachments/assets/5947e279-6533-466e-9eb1-f2036b0be073)

### New
![new-wide](https://github.com/user-attachments/assets/9e3aef0e-9dca-4a83-b4d2-ab512acb7abd)
