### PR TITLE
fix: omit latest only doc links from archive

### DIFF
--- a/templates/documentation-11.ftl
+++ b/templates/documentation-11.ftl
@@ -19,6 +19,7 @@
         <td>
         </td>
     </tr>
+<#if !archive>
     <tr>
         <td>
             <a href="${links.guides}#getting-started">
@@ -49,6 +50,7 @@
             Documentation specific to the server container image
         </td>
     </tr>
+</#if>
     <tr>
         <td>
             <a href="${docRoot}/securing_apps/index.html" target="_blank">

--- a/templates/documentation-12.ftl
+++ b/templates/documentation-12.ftl
@@ -19,6 +19,7 @@
         <td>
         </td>
     </tr>
+<#if !archive>
     <tr>
         <td>
             <a href="${links.guides}#getting-started">
@@ -59,6 +60,7 @@
             How to secure applications and services with Keycloak
         </td>
     </tr>
+</#if>
     <tr>
         <td>
             <a href="${docRoot}/server_admin/index.html" target="_blank">


### PR DESCRIPTION
closes: #656