### PR TITLE
Fixing keycloak test application

### DIFF
--- a/static/app/app.js
+++ b/static/app/app.js
@@ -15,11 +15,20 @@ function init() {
             clientId: conf.client
         });
 
+        function login() {
+            keycloak.login();
+        }
+
+        function logout() {
+            keycloak.logout();
+        }
+
         keycloak.init({
             checkLoginIframe: false
         }).then(function(auth) {
-            document.getElementById('login').onclick = keycloak.login;
-            document.getElementById('logout').onclick = keycloak.logout;
+            document.getElementById('login').onclick = login;
+            document.getElementById('logout').onclick = logout;
+            document.getElementById('clearConfig').onclick = clearConfig;
 
             show('config-view');
             hide('config-edit');
@@ -59,23 +68,34 @@ function hide(id) {
     document.getElementById(id).classList.remove('show');
 }
 
+function clearConfig() {
+    console.info("Clearing the configuration.");
+    if (window.location.href.includes('?')) {
+        window.location.href = window.location.href.split('?')[0];
+    }
+}
+
 function updateConfig() {
     var url = document.getElementById('url').value;
     var realm = document.getElementById('realm').value;
     var client = document.getElementById('client').value;
 
-    window.location.href = window.location.href.split('#')[0] + '#url=' + url + '&realm=' + realm + '&client=' + client;
+    window.location.href = window.location.href.split('?')[0] + '?url=' + url + '&realm=' + realm + '&client=' + client;
 }
 
 function loadConfig() {
-    var h = window.location.hash.substring(1).split('&');
+    var qstring = window.location.href.includes('?') ? window.location.href.split('?')[1] : '';
+    if (qstring.includes('#')) {
+        qstring = qstring.split('#')[0];
+    }
+    var h = qstring.split('&');
     var r = {};
     for (var i = 0; i < h.length; i++) {
         var t = h[i].split('=')
         r[t[0]] = t[1];
     }
+    console.info("Configuration loaded: " + JSON.stringify(r));
     return r;
 }
 
-window.onhashchange = init;
 init();

--- a/templates/app.ftl
+++ b/templates/app.ftl
@@ -12,7 +12,7 @@
                 <div id="config-view" class="hide my-3">
                     <a id="login" class="btn btn-primary hide">Sign in</a>
                     <a id="logout" class="btn btn-primary hide">Sign out</a>
-                    <a href="#" class="btn btn-secondary show">Clear config</a>
+                    <a id="clearConfig" class="btn btn-secondary show">Clear config</a>
                 </div>
                 <div id="config-edit" class="hide">
                     <form id="config-form">


### PR DESCRIPTION
closes #662

The testing application referenced from "Getting started" guides, which is available on https://www.keycloak.org/app/ is broken. Maybe this is related to the latest keycloak.js release. What I've fixed is:

- The methods like `keycloak.login` are not yet available during callback from the `keycloak.init` . Needed to add wrapper methods.
- Added the application configuration to the "query" instead of "fragment" . The keycloak.js itself is using fragment mode (for parsing params like `state` , `code` etc, which are sent after successful user login) and using fragment for the configuration did not work.