### PR TITLE
New extension: Client Certificate Lookup for Envoy

### DIFF
--- a/extensions/keycloak-client-cert-lookup-for-envoy.json
+++ b/extensions/keycloak-client-cert-lookup-for-envoy.json
@@ -1,0 +1,5 @@
+{
+  "name": "Client Certificate Lookup for Envoy",
+  "description": "Retrieves the client certificate from the x-forwarded-client-cert (XFCC) header set by Envoy Proxy.",
+  "website": "https://github.com/Nordix/keycloak-client-cert-lookup-for-envoy"
+}


### PR DESCRIPTION
This PR adds a new extension to the list: X509 Client Certificate Lookup for Envoy Proxy.

https://github.com/Nordix/keycloak-client-cert-lookup-for-envoy

@ahus1 suggested including it here long time ago https://github.com/keycloak/keycloak/pull/33159#issuecomment-2407019952 :blush: Better late than never! 

While there haven't been need for any new releases since the initial stable version, I’ve continued to maintain it, keeping it up to date and testing with newer Keycloak versions automatically via dependabot and github actions.