### PR TITLE
New extension: Vault Provider for OpenBao and HashiCorp Vault

### DIFF
--- a/extensions/keycloak-secrets-vault-provider.json
+++ b/extensions/keycloak-secrets-vault-provider.json
@@ -1,0 +1,5 @@
+{
+  "name": "Vault Provider for OpenBao and HashiCorp Vault",
+  "description": "Use OpenBao and HashiCorp Vault as external secret storage for Keycloak.",
+  "website": "https://github.com/Nordix/keycloak-secrets-vault-provider"
+}


### PR DESCRIPTION
This PR adds a new extension to the list: Vault Provider for OpenBao and HashiCorp Vault 

https://github.com/Nordix/keycloak-secrets-vault-provider

There are a few similar Vault SPI implementations for HashiCorp Vault, though no longer maintained. I hope this one is interesting enough to include. It comes with extensive documentation and also includes a custom Admin API extension for uploading secrets, which I believe makes the Vault SPI more practical to use.