### PR TITLE
Add Keycloak PSSO extension

### DIFF
--- a/extensions/keycloak-psso.json
+++ b/extensions/keycloak-psso.json
@@ -1,5 +1,5 @@
 {
   "name": "Keycloak Platform SSO",
-  "description": "Allows device and user registration of Apple's Platform Single Sign-on for macOS computers..",
-  "website": "https://github.com/unioslo/keycloak-psso-extension""
+  "description": "Allows device and user registration of Apple's Platform Single Sign-on for macOS computers.",
+  "website": "https://github.com/unioslo/keycloak-psso-extension"
 }

--- a/extensions/keycloak-psso.json
+++ b/extensions/keycloak-psso.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keycloak Platform SSO",
+  "description": "Allows device and user registration of Apple's Platform Single Sign-on for macOS computers..",
+  "website": "https://github.com/unioslo/keycloak-psso-extension""
+}


### PR DESCRIPTION
Keycloak PSSO Extension allows institutions that manage macOS machines with MDMs to use Apple's Platform Single Sign-on technology.

Homepage: https://github.com/unioslo/keycloak-psso-extension