### PR TITLE
Add HelmForge Keycloak Helm chart to community extensions

### DIFF
--- a/extensions/helmforge-keycloak-chart.json
+++ b/extensions/helmforge-keycloak-chart.json
@@ -1,0 +1,5 @@
+{
+  "name": "HelmForge Keycloak Helm Chart",
+  "description": "Production-ready Helm chart for Keycloak on Kubernetes with dev/production modes, external database support, and ingress configuration.",
+  "website": "https://github.com/helmforgedev/charts/tree/main/charts/keycloak"
+}


### PR DESCRIPTION
Community Helm chart for deploying Keycloak on Kubernetes, published as part of [HelmForge](https://helmforge.dev) — an MIT-licensed open-source Helm chart repository.

The chart supports dev and production modes, external database configuration (PostgreSQL, MySQL, MariaDB), separated management service, ingress with TLS, persistent themes, and full environment configuration via values.

- Chart source: https://github.com/helmforgedev/charts/tree/main/charts/keycloak
- ArtifactHub: https://artifacthub.io/packages/helm/helmforge/keycloak
- Documentation: https://helmforge.dev/docs/charts/keycloak

Suggested by @ahus1 in https://github.com/keycloak/keycloak/discussions/47671