### PR TITLE
add: keycloak-personal-access-tokens extension

### DIFF
--- a/extensions/keycloak-personal-access-tokens.json
+++ b/extensions/keycloak-personal-access-tokens.json
@@ -1,0 +1,5 @@
+{
+    "name": "Keycloak Personal Access Tokens",
+    "description": "A Keycloak plugin that lets users create personal access tokens (PATs) — scoped, named tokens that can be used as passwords anywhere HTTP Basic Auth is accepted",
+    "website": "https://github.com/mrulex-repo/keycloak-personal-access-tokens"
+}


### PR DESCRIPTION
Add a new extension entry for Keycloak Personal Access Tokens, a plugin that enables users to create scoped, named tokens usable as passwords wherever HTTP Basic Auth is accepted. The entry includes the extension name, description, and upstream GitHub repository link.