### PR TITLE
add: keycloak-shadcn extension

### DIFF
--- a/extensions/keycloak-shadcn.json
+++ b/extensions/keycloak-shadcn.json
@@ -1,0 +1,5 @@
+{
+    "name": "Keycloak shadcn Theme",
+    "description": "A Keycloakify-based Keycloak theme built with shadcn/ui where light/dark logo, favicon and theme colors are configurable at runtime from the admin console — no theme rebuild required. Ships a bundled Theme Config SPI (REST endpoint + Realm Settings UI tab)",
+    "website": "https://github.com/emirhannaneli/keycloak-shadcn"
+}


### PR DESCRIPTION
Add a new extension entry for Keycloak shadcn Theme — a Keycloakify-based
Keycloak theme built with shadcn/ui that lets admins configure light/dark
logo, favicon and theme colors at runtime from the admin console, with no
theme rebuild required. The entry adds the extension name, description, and
upstream GitHub repository link.