### PR TITLE
feat: add minecraft idp to plugins collection

### DIFF
--- a/extensions/keycloak-minecraft-idp.json
+++ b/extensions/keycloak-minecraft-idp.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keycloak Minecraft Identity Provider",
+  "description": "A Keycloak Identity Provider plugin that enables authentication via Microsoft/Xbox OAuth2 and resolves the brokered login identity to the Minecraft Java player name when a Java profile exists, otherwise to the Xbox Gamertag for supported Bedrock logins.",
+  "website": "https://github.com/groundsgg/keycloak-minecraft-idp"
+}


### PR DESCRIPTION
## Summary

Adds the [keycloak-minecraft-idp](https://github.com/groundsgg/keycloak-minecraft-idp) extension to the Keycloak website extensions catalog, as requested in [#750](https://github.com/keycloak/keycloak-web/issues/750).

The plugin lets Keycloak authenticate users via Microsoft/Xbox OAuth2 and use the Minecraft Java username (or Xbox Gamertag for supported Bedrock logins) as the brokered identity—useful for Minecraft server networks, communities, and platforms that need verified Minecraft accounts in a Keycloak-based flow.

Closes #750