### PR TITLE
New Extension: Cap Captcha

### DIFF
--- a/extensions/cap-captcha.json
+++ b/extensions/cap-captcha.json
@@ -1,0 +1,5 @@
+{
+  "name": "Cap Captcha",
+  "description": "Adds trycap.dev cap (proof-of-work + instrumentation) CAPTCHA validation to the Keycloak registration flow. Self-hostable, fail-closed server-side verification via cap's reCAPTCHA-compatible siteverify endpoint.",
+  "website": "https://github.com/schwebke/cap-captcha-keycloak"
+}


### PR DESCRIPTION
## Summary

Adds the [cap-captcha-keycloak](https://github.com/schwebke/cap-captcha-keycloak) extension to the Keycloak website extensions catalog.

It is a Keycloak extension providing [trycap.dev cap](https://trycap.dev/) captcha validation for the registration flow. Cap is a self-hostable proof-of-work + instrumentation CAPTCHA; the extension verifies the token server-side via cap's reCAPTCHA-compatible `siteverify` endpoint and is fail-closed (no bypass on error), matching the scope and semantics of Keycloak's native `RegistrationRecaptcha`. Useful for Keycloak deployments that want a self-hostable, privacy-friendly alternative to cloud CAPTCHAs on user registration.

Closes #773