### PR TITLE
Add keycloak alias guard extension

### DIFF
--- a/extensions/keycloak-alias-guard.json
+++ b/extensions/keycloak-alias-guard.json
@@ -1,6 +1,6 @@
 {
   "name": "Alias Guard",
   "description": "User Profile validator and event listener that canonicalizes email addresses (Gmail dots, +tags) and blocks registration or email change when the mailbox is already taken. One inbox — one account.",
-  "website": "https://github.com/dnwsilver/keycloak-alias-guard"
+  "website": "https://github.com/it-perspectives/keycloak-alias-guard"
 }
 

--- a/extensions/keycloak-alias-guard.json
+++ b/extensions/keycloak-alias-guard.json
@@ -1,0 +1,6 @@
+{
+  "name": "Alias Guard",
+  "description": "User Profile validator and event listener that canonicalizes email addresses (Gmail dots, +tags) and blocks registration or email change when the mailbox is already taken. One inbox — one account.",
+  "website": "https://github.com/dnwsilver/keycloak-alias-guard"
+}
+


### PR DESCRIPTION
## Summary

Adds the [keycloak-alias-guard](https://github.com/it-perspectives/keycloak-alias-guard) extension to the Keycloak website extensions catalog.

## What it does

Keycloak SPI provider: canonicalizes email addresses (Gmail/Googlemail dot removal and +tag stripping; +tag stripping on other domains) and blocks registration or email update when the canonical mailbox is already taken.

| Component | Provider ID | Role |
|-----------|-------------|------|
| User Profile validator | `alias-guard` | Blocks duplicate mailbox on registration and email update |
| Event listener | `alias-guard-listener` | Writes `email_canonical` user attribute for fast lookup |

Requires Keycloak **26.5.x** with declarative User Profile (`declarative-user-profile`). MIT licensed.

Closes #775 