### PR TITLE
Create email-mtls.json to add  email-mtls to Extensions page

### DIFF
--- a/extensions/email-mtls.json
+++ b/extensions/email-mtls.json
@@ -1,0 +1,5 @@
+{
+  "name": "Email-mTLS",
+  "description": "Drop-in replacement for the built-in Keycloak email provider that adds mutual TLS (mTLS) support for SMTP connections.",
+  "website": "https://github.com/nokia/keycloak-ext/tree/main/email-mtls"
+}


### PR DESCRIPTION
Adds the [Email-mTLS](https://github.com/nokia/keycloak-ext/tree/main/email-mtls) extension to the Keycloak website Extensions catalog.

The extension behaves like the built-in Keycloak email provider but adds
mutual TLS (mTLS) support for SMTP connections through a dedicated keystore.

Closes #785