### PR TITLE
Add Keycloak Account Events extension

### DIFF
--- a/extensions/keycloak-account-events.json
+++ b/extensions/keycloak-account-events.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keycloak Account Events",
+  "description": "Self-service login history: users read their own authentication events with their own account access token, no admin credentials needed.",
+  "website": "https://github.com/AdrianIAna/keycloak-account-events"
+}


### PR DESCRIPTION
Adds the extension entry for keycloak-account-events, a self-service login history endpoint (users read their own authentication events with their own account token).

Closes #793