### PR TITLE
Add Keycloak Event Enrichment extension

### DIFF
--- a/extensions/keycloak-event-enrichment.json
+++ b/extensions/keycloak-event-enrichment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keycloak Event Enrichment",
+  "description": "Enriches authentication events with GeoIP location and parsed User-Agent details (MaxMind GeoLite2) before persistence.",
+  "website": "https://github.com/AdrianIAna/keycloak-event-enrichment"
+}


### PR DESCRIPTION
Adds the extension entry for keycloak-event-enrichment, which enriches authentication events with GeoIP location and User-Agent details at persistence time.

Closes #794