### PR TITLE
Add Keycloak WS-Federation extension

### DIFF
--- a/extensions/keycloak-ws-federation.json
+++ b/extensions/keycloak-ws-federation.json
@@ -1,0 +1,5 @@
+{
+  "name": "Keycloak WS-Federation",
+  "description": "WS-Federation 1.2 passive-requestor protocol and identity broker extension for Keycloak 26.7.x.",
+  "website": "https://github.com/ChosoMeister/Keycloak-WS-Federation"
+}


### PR DESCRIPTION
## Summary

Adds Keycloak WS-Federation as a separate community extension without modifying the existing WS-Federation protocol listing.

The extension provides a maintained WS-Federation 1.2 passive-requestor protocol and identity broker implementation for Keycloak 26.7.x and Java 21. It supports Keycloak as an Identity Provider / STS and brokering to external providers such as AD FS.

## Project readiness

- Quarkus provider deployment and optimized container build
- Published `v26.7.0-1` JAR and SHA-256 checksum
- Unit, Docker, PostgreSQL, metadata, login-flow, and configuration integration tests
- English and Persian installation, production rollout, rollback, configuration, and troubleshooting documentation
- GNU AGPL-3.0 repository license with retained file-level notices

Closes #797
