### PR TITLE
Add 7 missing CVE advisories to Keycloak 26.7.1 release notes

### DIFF
--- a/cache/releases/keycloak/26.7.1/changelog.json
+++ b/cache/releases/keycloak/26.7.1/changelog.json
@@ -89,4 +89,53 @@
   "kind" : "bug",
   "area" : "core",
   "url" : "https://github.com/keycloak/keycloak/issues/50928"
+}, {
+  "number" : 51467,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-15573 Authorization bypass via unnormalized uri matching in pathmatcher",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51467"
+}, {
+  "number" : 51468,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-15572 DCR protocol mapper type-swap policy bypass allows privilege escalation",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51468"
+}, {
+  "number" : 51469,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-16100 Unbounded metric cardinality in user event metrics via request-controlled error text",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51469"
+}, {
+  "number" : 51470,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-16442 SAML idp-initiated broker login bypasses link-only restriction",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51470"
+}, {
+  "number" : 51471,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-16443 SAML broker metadata import disables response signature validation",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51471"
+}, {
+  "number" : 51472,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-16071 LDAP entry-dn user search bypasses configured users dn boundary",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51472"
+}, {
+  "number" : 51473,
+  "repository" : "keycloak",
+  "title" : "CVE-2026-16102 Default DCR policy allows role forgery via user property mappers",
+  "kind" : "cve",
+  "area" : null,
+  "url" : "https://github.com/keycloak/keycloak/issues/51473"
 } ]


### PR DESCRIPTION
## Summary

The [Keycloak 26.7.1 release announcement](https://www.keycloak.org/2026/08/keycloak-2671-released) lists **5 security fixes**, but the release actually resolves **12 CVEs**.

The `cache/releases/keycloak/26.7.1/changelog.json` cache was generated on 2026-08-05 (release day). Seven further security advisories were published on 2026-08-06 and labeled `release/26.7.1` (and `release/26.6.5` / `release/26.4.14`) **after** the cache had been generated, so `ChangelogBuilder` never picked them up — the committed cache is read as-is on subsequent builds.

This PR adds the 7 missing entries so the release notes list all 12 security fixes.

## Missing CVEs added

| Issue | CVE | Summary |
|-------|-----|---------|
| [#51467](https://github.com/keycloak/keycloak/issues/51467) | CVE-2026-15573 | Authorization bypass via unnormalized URI matching in PathMatcher |
| [#51468](https://github.com/keycloak/keycloak/issues/51468) | CVE-2026-15572 | DCR protocol mapper type-swap policy bypass allows privilege escalation |
| [#51469](https://github.com/keycloak/keycloak/issues/51469) | CVE-2026-16100 | Unbounded metric cardinality in user event metrics via request-controlled error text |
| [#51470](https://github.com/keycloak/keycloak/issues/51470) | CVE-2026-16442 | SAML IdP-initiated broker login bypasses link-only restriction |
| [#51471](https://github.com/keycloak/keycloak/issues/51471) | CVE-2026-16443 | SAML broker metadata import disables response signature validation |
| [#51472](https://github.com/keycloak/keycloak/issues/51472) | CVE-2026-16071 | LDAP entry-DN user search bypasses configured users-DN boundary |
| [#51473](https://github.com/keycloak/keycloak/issues/51473) | CVE-2026-16102 | Default DCR policy allows role forgery via user property mappers |

## Notes

- Entries match the format `ChangelogBuilder` produces: raw issue title, `kind` from the `kind/*` label (`cve`), and `area` from the `area/*` label — none of these issues carry an `area/*` label, so `area` is `null` (consistent with existing entries without an area).
- Entries are appended in ascending issue-number order, as the generator sorts them.
- JSON validated; the array now contains 12 `cve`, 6 `bug` and 2 `task` entries.