### PR TITLE
Update the Apache APISIX guide link

### DIFF
--- a/guides/securing-apps/apisix.adoc
+++ b/guides/securing-apps/apisix.adoc
@@ -1,3 +1,3 @@
 :guide-title: Apache APISIX
 :guide-summary: Integrate Keycloak for Authentication with Apache APISIX
-:external-link: https://apisix.apache.org/blog/2021/12/10/integrate-keycloak-auth-in-apisix
+:external-link: https://apisix.apache.org/docs/apisix/tutorials/keycloak-oidc/


### PR DESCRIPTION
### Summary

Update the existing Apache APISIX external guide entry to point to the maintained APISIX Keycloak OIDC tutorial instead of the December 2021 blog post.

The guide title and summary remain unchanged, and the archived Keycloak blog post is not modified.

### Validation

- Confirmed that the new external URL returns HTTP 200.
- Confirmed that the destination documents the Keycloak integration through the APISIX `openid-connect` plugin.
- Ran `./mvnw -B -s mvn-rel-settings.xml package -Dpublish` successfully and inspected the generated Guides page.
- Confirmed that the generated entry retains the existing title and summary and points to the new URL.

The repository's GitHub Action site-wide link check was not run locally; the pull request CI will provide that check.

### Disclosure

I am an Apache APISIX Committer.

I used an AI agent to assist with repository research and preparation of this small documentation change. I reviewed and understand the change and will personally handle review feedback.

Closes #815
